### PR TITLE
fix: repair QR export — zip download and VDP manifest broken since qr_png_url was deprecated

### DIFF
--- a/app/api/campaigns/[campaignId]/vdp-manifest/route.ts
+++ b/app/api/campaigns/[campaignId]/vdp-manifest/route.ts
@@ -21,6 +21,15 @@ export async function GET(
   { params }: { params: Promise<{ campaignId: string }> }
 ) {
   try {
+    /*
+     * Generates the VDP CSV that printers use to merge address data and QR URLs
+     * into print templates. Web-generated campaigns store QR images in
+     * campaign_addresses.qr_code_base64 and the encoded scan URL in purl; the
+     * qr_codes table is not populated by generate-qrs. This route now filters
+     * on the active base64 QR field and uses purl as qr_url so the CSV matches
+     * the printed QR image exactly. See QR_SYSTEM.md for the full context and
+     * future slug-based Model B migration.
+     */
     const { campaignId } = await params;
 
     if (!campaignId) {
@@ -66,7 +75,6 @@ export async function GET(
     const adminSupabase = createAdminClient();
 
     // Fetch addresses with QR codes
-    // Include both qr_png_url (legacy) and check for qr_codes table entries (modern)
     const { data: addresses, error: addressesError } = await adminSupabase
       .from('campaign_addresses')
       .select(`
@@ -75,10 +83,11 @@ export async function GET(
         formatted,
         postal_code,
         qr_png_url,
+        purl,
         seq
       `)
       .eq('campaign_id', campaignId)
-      .not('qr_png_url', 'is', null)
+      .not('qr_code_base64', 'is', null)
       .order('seq', { ascending: true, nullsFirst: false })
       .order('id', { ascending: true });
 
@@ -96,18 +105,6 @@ export async function GET(
         { status: 404 }
       );
     }
-
-    // Fetch QR codes from qr_codes table for addresses that have them (modern system)
-    const addressIds = addresses.map((a) => a.id);
-    const { data: qrCodes } = await adminSupabase
-      .from('qr_codes')
-      .select('id, slug, qr_url, address_id')
-      .in('address_id', addressIds);
-
-    // Create a map of address_id -> qr_code for quick lookup
-    const qrCodeMap = new Map(
-      (qrCodes || []).map((qc) => [qc.address_id, qc])
-    );
 
     // Parse address components from formatted address
     const parseAddress = (formatted: string) => {
@@ -149,20 +146,18 @@ export async function GET(
     // Generate CSV rows
     const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.APP_BASE_URL || 'https://flyrpro.app';
     const rows = addresses.map((address, index) => {
-      const qrCode = qrCodeMap.get(address.id);
-      
-      // Use short slug URL if available, otherwise construct from qr_png_url or use legacy URL
-      let qrUrl: string;
-      if (qrCode?.qr_url) {
-        // Modern system: use short slug URL
-        qrUrl = qrCode.qr_url;
-      } else if (qrCode?.slug) {
-        // Has slug but no qr_url, construct it
-        qrUrl = `${baseUrl}/q/${qrCode.slug}`;
-      } else {
-        // Legacy system: construct URL from address ID
-        qrUrl = `${baseUrl}/api/open?addressId=${address.id}`;
-      }
+      // qr_url for the CSV: use the purl column which contains the exact
+      // URL already encoded in the printed QR image (/api/scan?id={address_id}).
+      // This ensures the URL in the CSV and the URL in the QR code are always
+      // identical and consistent.
+      //
+      // Note: We intentionally do not use the qr_codes table here. The qr_codes
+      // table is empty for web-generated campaigns (generate-qrs does not insert
+      // there). A future migration to slug-based URLs (/q/{slug}) will update
+      // this when a staging environment is available. See QR_SYSTEM.md Section 8
+      // for the full fix specification.
+      const qrUrl = address.purl
+        || `${baseUrl}/api/scan?id=${address.id}`;
 
       const addressParts = parseAddress(address.formatted || address.address || '');
       const referenceId = `REF-${String(index + 1).padStart(6, '0')}`;

--- a/app/api/zip-qrs/route.ts
+++ b/app/api/zip-qrs/route.ts
@@ -9,6 +9,14 @@ import { getSupabaseAnonKey, getSupabaseUrl } from '@/lib/supabase/env';
 
 export async function GET(request: NextRequest) {
   try {
+    /*
+     * Builds a printer-ready QR ZIP for a campaign: one PNG per address,
+     * a vdp-manifest.csv, and README.txt instructions. Web-generated QR
+     * campaigns store the PNG data URI in campaign_addresses.qr_code_base64,
+     * not in the older Supabase Storage URL column, so this route now reads
+     * the active Model A data written by generate-qrs. See QR_SYSTEM.md for
+     * full context and the future Model B migration plan.
+     */
     const searchParams = request.nextUrl.searchParams;
     const campaignId = searchParams.get('campaignId');
 
@@ -62,7 +70,7 @@ export async function GET(request: NextRequest) {
       .from('campaign_addresses')
       .select('*')
       .eq('campaign_id', campaignId)
-      .not('qr_png_url', 'is', null)
+      .not('qr_code_base64', 'is', null)
       .order('seq', { ascending: true, nullsFirst: false })
       .order('id', { ascending: true });
 
@@ -86,19 +94,18 @@ export async function GET(request: NextRequest) {
 
     for (const address of addresses) {
       try {
-        // Extract the file path from the public URL
-        const url = new URL(address.qr_png_url);
-        const filePath = url.pathname.split('/storage/v1/object/public/qr/')[1];
-
-        // Download from Supabase Storage
-        const { data, error } = await adminSupabase.storage
-          .from('qr')
-          .download(filePath);
-
-        if (error || !data) {
-          console.error(`Error downloading ${filePath}:`, error);
+        // QR images are stored as base64 data URIs in campaign_addresses.qr_code_base64.
+        // Strip the data URI prefix (e.g. "data:image/png;base64,") to get raw base64,
+        // then convert to a Buffer for inclusion in the ZIP.
+        // Note: qr_png_url (Supabase Storage URL) is always NULL for web-generated
+        // campaigns — generate-qrs was updated to use base64 storage instead.
+        // See QR_SYSTEM.md for full context.
+        if (!address.qr_code_base64) {
+          console.error(`Address ${address.id} has no qr_code_base64, skipping`);
           continue;
         }
+        const base64Data = address.qr_code_base64.replace(/^data:image\/\w+;base64,/, '');
+        const data = Buffer.from(base64Data, 'base64');
 
         // Add to ZIP
         const addressLabel = (address.formatted || address.address || 'address').replace(/[^a-z0-9]/gi, '_');

--- a/components/RecipientsTable.tsx
+++ b/components/RecipientsTable.tsx
@@ -237,6 +237,14 @@ export function RecipientsTable({ recipients, campaignId, onRefresh }: Recipient
                           {loading === recipient.id ? 'Updating...' : 'Mark Attempted'}
                         </Button>
                       )}
+                      {/*
+                        TODO: This button never renders because qr_png_url is always passed
+                        as null from the campaign page (app/(main)/campaigns/[campaignId]/page.tsx).
+                        generate-qrs writes qr_code_base64 and purl, not qr_png_url.
+                        Future fix: either pass purl as a prop and link to it here,
+                        or implement a proper QR download button that uses qr_code_base64.
+                        See QR_SYSTEM.md Section 6 for full context.
+                      */}
                       {recipient.qr_png_url && (
                         <Button
                           size="sm"


### PR DESCRIPTION
## What this does
Fixes the ZIP download and VDP print manifest which have been
returning empty results for all web-generated campaigns. Users 
could see QR thumbnails on screen but could not download them for printing.

## Root cause
generate-qrs writes QR images to campaign_addresses.qr_code_base64.
An older version wrote to Supabase Storage and stored the URL in
campaign_addresses.qr_png_url. That was changed but zip-qrs and
vdp-manifest were never updated — they still filtered on qr_png_url
which is always NULL. Both routes always returned empty.

Full analysis in QR_SYSTEM.md.

## Changes

**app/api/zip-qrs/route.ts**
- Changed filter from .not('qr_png_url', 'is', null) to
  .not('qr_code_base64', 'is', null)
- Replaced Supabase Storage download with base64 Buffer conversion
  (no Storage dependency needed — images are in the DB row)
- Added maintainer comment explaining the QR data model

**app/api/campaigns/[campaignId]/vdp-manifest/route.ts**
- Changed filter from .not('qr_png_url', 'is', null) to
  .not('qr_code_base64', 'is', null)
- Removed qr_codes table lookup (empty for web campaigns)
- qr_url in CSV now uses address.purl — the exact URL already
  encoded in the printed QR image, ensuring CSV and QR are
  always consistent
- Added maintainer comment explaining the QR data model

**components/RecipientsTable.tsx**
- Added TODO comment above the dead View QR button explaining
  why it never renders and proposing a future fix
  (qr_png_url is always passed as null from the campaign page)

## What did NOT change
- No database writes or schema changes
- No changes to how QR codes are generated
- No changes to scan tracking or homeowner redirect behavior
- iOS app is completely unaffected — it does not call these routes
- Existing analytics are unchanged

## Verified locally
- npx tsc --noEmit: clean
- npm run build: 0 errors