### PR TITLE
fix: guard map layer operations against style transitions on campaign pages

### DIFF
--- a/app/(main)/campaigns/create/page.tsx
+++ b/app/(main)/campaigns/create/page.tsx
@@ -89,6 +89,11 @@ export default function CreateCampaignPage() {
   const add2DBuildingsLayer = (m: mapboxgl.Map) => {
     const buildingLayerId = '2d-buildings';
     if (m.getLayer(buildingLayerId)) return; // already added
+    // Only add the composite building overlay for Mapbox styles that
+    // include the composite source. Custom styles (PMTiles, external
+    // tilesets) do not have composite and will throw if we attempt
+    // to add a layer from it.
+    if (!m.getSource('composite')) return;
     const buildingFill = isDark ? '#111111' : '#c8c1b2';
     const buildingOutline = isDark ? '#0a0a0a' : '#b5ad9d';
 

--- a/components/map/MapBuildingsLayer.tsx
+++ b/components/map/MapBuildingsLayer.tsx
@@ -1744,7 +1744,14 @@ export function MapBuildingsLayer({
 
   // Update color and filter when statusFilters or campaignId changes
   useEffect(() => {
-    if (!map || !map.getLayer(layerId)) return;
+    // map.getLayer can throw during style transitions (setStyle clears
+    // the layer registry temporarily). Guard with isStyleLoaded() and
+    // catch any transient Mapbox internal errors.
+    try {
+      if (!map || !map.isStyleLoaded() || !map.getLayer(layerId)) return;
+    } catch {
+      return;
+    }
     
     try {
       const colorExpr = getFootprintFillColor();


### PR DESCRIPTION
## What this does
Fixes two separate Mapbox errors that were crashing the campaign 
detail page and throwing console errors on the campaign create page.

## Changes

**components/map/MapBuildingsLayer.tsx**
Fixed a crash that occurred when switching map views on the campaign 
detail page. The `useEffect` that updates building layer colors and 
filters was calling `map.getLayer()` during a Mapbox style transition, 
when the layer registry is temporarily unavailable. Added 
`map.isStyleLoaded()` guard and a try/catch to handle the transient 
error safely.

**app/(main)/campaigns/create/page.tsx**
Fixed a console error on the campaign create page when using a custom 
or PMTiles-based map style. The `add2DBuildingsLayer` function 
unconditionally added a layer using the `composite` source, which only 
exists in standard Mapbox styles (Streets, Satellite, etc.). Added a 
`map.getSource('composite')` guard so the overlay is silently skipped 
for styles that don't include it.

## Root cause
Both errors were race/compatibility conditions. The 
map fix was previously masked by disabled build gates and only surfaced 
during manual testing.

## Verified locally
- npx tsc --noEmit: clean
- npm run build: 0 errors
- Confirmed no getOwnLayer crash on campaign detail page
- Confirmed no composite source error on campaign create page