### PR TITLE
fix: convert all layer-scoped map event listeners to guarded map-level handlers

### DIFF
--- a/components/campaigns/CampaignDetailMapView.tsx
+++ b/components/campaigns/CampaignDetailMapView.tsx
@@ -1245,6 +1245,20 @@ export function CampaignDetailMapView({
       }
     };
 
+    // Use a map-level click handler so Mapbox does not run layer-scoped
+    // queryRenderedFeatures internally during style transitions.
+    const onPointOverlayMapClick = (e: mapboxgl.MapMouseEvent) => {
+      try {
+        if (!mapInstance.isStyleLoaded() || !mapInstance.getLayer(pointOverlayCircleLayerId)) return;
+        const features = mapInstance.queryRenderedFeatures(e.point, {
+          layers: [pointOverlayCircleLayerId],
+        });
+        if (features.length > 0) onPointOverlayClick(Object.assign(e, { features }));
+      } catch {
+        return;
+      }
+    };
+
     if (pointOverlays.length === 0) {
       removePointOverlayLayers();
       return;
@@ -1256,11 +1270,11 @@ export function CampaignDetailMapView({
       mapInstance.once('style.load', addPointOverlayLayers);
     }
 
-    mapInstance.off('click', pointOverlayCircleLayerId, onPointOverlayClick);
-    mapInstance.on('click', pointOverlayCircleLayerId, onPointOverlayClick);
+    mapInstance.off('click', onPointOverlayMapClick);
+    mapInstance.on('click', onPointOverlayMapClick);
 
     return () => {
-      mapInstance.off('click', pointOverlayCircleLayerId, onPointOverlayClick);
+      mapInstance.off('click', onPointOverlayMapClick);
       removePointOverlayLayers();
     };
   }, [handleMapTargetClick, mapLoaded, pointOverlays, resolvedMapStyle.key]);
@@ -1728,18 +1742,44 @@ export function CampaignDetailMapView({
       }
     };
 
-    const setParcelCursor = () => {
-      m.getCanvas().style.cursor = 'pointer';
+    // Use a map-level click handler so Mapbox does not run layer-scoped
+    // queryRenderedFeatures internally during style transitions.
+    const onParcelMapClick = (e: mapboxgl.MapMouseEvent) => {
+      try {
+        if (!m.isStyleLoaded() || !m.getLayer(PARCEL_FILL_LAYER)) return;
+        const features = m.queryRenderedFeatures(e.point, {
+          layers: [PARCEL_FILL_LAYER],
+        });
+        if (features.length > 0) onParcelClick(Object.assign(e, { features }));
+      } catch {
+        return;
+      }
     };
 
-    const clearParcelCursor = () => {
-      m.getCanvas().style.cursor = '';
+    // Replace layer-scoped mouseenter/mouseleave with a map-level
+    // mousemove handler. Layer-scoped hover events cause Mapbox to
+    // internally call queryRenderedFeatures on every mousemove, which
+    // throws during style transitions when the layer registry is
+    // temporarily unavailable. A map-level mousemove with explicit
+    // isStyleLoaded() and try/catch guards avoids this entirely.
+    const onParcelMouseMove = (e: mapboxgl.MapMouseEvent) => {
+      try {
+        if (!m.isStyleLoaded() || !m.getLayer(PARCEL_FILL_LAYER)) {
+          m.getCanvas().style.cursor = '';
+          return;
+        }
+        const features = m.queryRenderedFeatures(e.point, {
+          layers: [PARCEL_FILL_LAYER],
+        });
+        m.getCanvas().style.cursor = features.length > 0 ? 'pointer' : '';
+      } catch {
+        m.getCanvas().style.cursor = '';
+      }
     };
 
     if (!showParcels) {
-      m.off('click', PARCEL_FILL_LAYER, onParcelClick);
-      m.off('mouseenter', PARCEL_FILL_LAYER, setParcelCursor);
-      m.off('mouseleave', PARCEL_FILL_LAYER, clearParcelCursor);
+      m.off('click', onParcelMapClick);
+      m.off('mousemove', onParcelMouseMove);
       removeParcelsLayer();
       return;
     }
@@ -1750,17 +1790,14 @@ export function CampaignDetailMapView({
       m.once('style.load', addParcelsLayer);
     }
 
-    m.off('click', PARCEL_FILL_LAYER, onParcelClick);
-    m.off('mouseenter', PARCEL_FILL_LAYER, setParcelCursor);
-    m.off('mouseleave', PARCEL_FILL_LAYER, clearParcelCursor);
-    m.on('click', PARCEL_FILL_LAYER, onParcelClick);
-    m.on('mouseenter', PARCEL_FILL_LAYER, setParcelCursor);
-    m.on('mouseleave', PARCEL_FILL_LAYER, clearParcelCursor);
+    m.off('click', onParcelMapClick);
+    m.off('mousemove', onParcelMouseMove);
+    m.on('click', onParcelMapClick);
+    m.on('mousemove', onParcelMouseMove);
 
     return () => {
-      m.off('click', PARCEL_FILL_LAYER, onParcelClick);
-      m.off('mouseenter', PARCEL_FILL_LAYER, setParcelCursor);
-      m.off('mouseleave', PARCEL_FILL_LAYER, clearParcelCursor);
+      m.off('click', onParcelMapClick);
+      m.off('mousemove', onParcelMouseMove);
       removeParcelsLayer();
     };
   }, [

--- a/components/map/CampaignAddressPmtilesLayer.tsx
+++ b/components/map/CampaignAddressPmtilesLayer.tsx
@@ -411,14 +411,47 @@ export function CampaignAddressPmtilesLayer({
         map.getCanvas().style.cursor = '';
       };
 
-      map.on('click', CIRCLE_LAYER_ID, clickHandler);
-      map.on('mouseenter', CIRCLE_LAYER_ID, enterHandler);
-      map.on('mouseleave', CIRCLE_LAYER_ID, leaveHandler);
+      // Use map-level handlers so Mapbox does not run layer-scoped
+      // queryRenderedFeatures internally during style transitions.
+      const mapClickHandler = (event: mapboxgl.MapMouseEvent) => {
+        try {
+          if (!map.isStyleLoaded() || !map.getLayer(CIRCLE_LAYER_ID)) return;
+          const features = map.queryRenderedFeatures(event.point, {
+            layers: [CIRCLE_LAYER_ID],
+          });
+          if (features.length > 0) clickHandler(Object.assign(event, { features }));
+        } catch {
+          return;
+        }
+      };
+
+      // Use map-level mousemove so hover does not depend on Mapbox's
+      // layer-scoped mouseenter/mouseleave dispatch during style transitions.
+      const mapMouseMoveHandler = (event: mapboxgl.MapMouseEvent) => {
+        try {
+          if (!map.isStyleLoaded() || !map.getLayer(CIRCLE_LAYER_ID)) {
+            leaveHandler();
+            return;
+          }
+          const features = map.queryRenderedFeatures(event.point, {
+            layers: [CIRCLE_LAYER_ID],
+          });
+          if (features.length > 0) {
+            enterHandler();
+          } else {
+            leaveHandler();
+          }
+        } catch {
+          leaveHandler();
+        }
+      };
+
+      map.on('click', mapClickHandler);
+      map.on('mousemove', mapMouseMoveHandler);
 
       return () => {
-        map.off('click', CIRCLE_LAYER_ID, clickHandler);
-        map.off('mouseenter', CIRCLE_LAYER_ID, enterHandler);
-        map.off('mouseleave', CIRCLE_LAYER_ID, leaveHandler);
+        map.off('click', mapClickHandler);
+        map.off('mousemove', mapMouseMoveHandler);
       };
     };
 

--- a/components/map/MapBuildingsLayer.tsx
+++ b/components/map/MapBuildingsLayer.tsx
@@ -1039,14 +1039,44 @@ export function MapBuildingsLayer({
         map.getCanvas().style.cursor = '';
       };
 
-      map.on('click', layerId, clickHandler);
-      map.on('mouseenter', layerId, enterHandler);
-      map.on('mouseleave', layerId, leaveHandler);
+      // Use map-level handlers so Mapbox does not run layer-scoped
+      // queryRenderedFeatures internally during style transitions.
+      const mapClickHandler = (event: mapboxgl.MapMouseEvent) => {
+        try {
+          if (!map.isStyleLoaded() || !map.getLayer(layerId)) return;
+          const features = map.queryRenderedFeatures(event.point, {
+            layers: [layerId],
+          });
+          if (features.length > 0) clickHandler(Object.assign(event, { features }));
+        } catch {
+          return;
+        }
+      };
+      const mapMouseMoveHandler = (event: mapboxgl.MapMouseEvent) => {
+        try {
+          if (!map.isStyleLoaded() || !map.getLayer(layerId)) {
+            leaveHandler();
+            return;
+          }
+          const features = map.queryRenderedFeatures(event.point, {
+            layers: [layerId],
+          });
+          if (features.length > 0) {
+            enterHandler();
+          } else {
+            leaveHandler();
+          }
+        } catch {
+          leaveHandler();
+        }
+      };
+
+      map.on('click', mapClickHandler);
+      map.on('mousemove', mapMouseMoveHandler);
 
       return () => {
-        map.off('click', layerId, clickHandler);
-        map.off('mouseenter', layerId, enterHandler);
-        map.off('mouseleave', layerId, leaveHandler);
+        map.off('click', mapClickHandler);
+        map.off('mousemove', mapMouseMoveHandler);
       };
     };
 
@@ -1189,6 +1219,8 @@ export function MapBuildingsLayer({
     if (!map) {
       return;
     }
+
+    let cleanupLayerInteractionHandlers: (() => void) | undefined;
 
     // Define the update logic as a function we can call or defer
     const updateLayers = () => {
@@ -1620,31 +1652,55 @@ export function MapBuildingsLayer({
           }
         };
 
-        map.on('click', layerId, clickHandler);
+        cleanupLayerInteractionHandlers?.();
 
-        // Change cursor on hover
-        map.on('mouseenter', layerId, () => {
-          if (map.getCanvas()) {
-            map.getCanvas().style.cursor = 'pointer';
+        const getInteractiveLayers = () => {
+          const layers: string[] = [];
+          try {
+            if (!map.isStyleLoaded()) return layers;
+            if (map.getLayer(layerId)) layers.push(layerId);
+            if (map.getLayer(circleLayerId)) layers.push(circleLayerId);
+          } catch {
+            return [];
           }
-        });
+          return layers;
+        };
 
-        map.on('mouseleave', layerId, () => {
-          if (map.getCanvas()) {
+        // Use map-level handlers so Mapbox does not run layer-scoped
+        // queryRenderedFeatures internally during style transitions.
+        const mapClickHandler = (event: mapboxgl.MapMouseEvent) => {
+          try {
+            const layers = getInteractiveLayers();
+            if (layers.length === 0) return;
+            const features = map.queryRenderedFeatures(event.point, { layers });
+            if (features.length > 0) void clickHandler(Object.assign(event, { features }));
+          } catch {
+            return;
+          }
+        };
+
+        // Use map-level mousemove so hover does not depend on Mapbox's
+        // layer-scoped mouseenter/mouseleave dispatch during style transitions.
+        const mapMouseMoveHandler = (event: mapboxgl.MapMouseEvent) => {
+          try {
+            const layers = getInteractiveLayers();
+            if (layers.length === 0) {
+              map.getCanvas().style.cursor = '';
+              return;
+            }
+            const features = map.queryRenderedFeatures(event.point, { layers });
+            map.getCanvas().style.cursor = features.length > 0 ? 'pointer' : '';
+          } catch {
             map.getCanvas().style.cursor = '';
           }
-        });
+        };
 
-        // Also register click + cursor handlers on the circle layer (Point features)
-        if (map.getLayer(circleLayerId)) {
-          map.on('click', circleLayerId, clickHandler);
-          map.on('mouseenter', circleLayerId, () => {
-            if (map.getCanvas()) map.getCanvas().style.cursor = 'pointer';
-          });
-          map.on('mouseleave', circleLayerId, () => {
-            if (map.getCanvas()) map.getCanvas().style.cursor = '';
-          });
-        }
+        map.on('click', mapClickHandler);
+        map.on('mousemove', mapMouseMoveHandler);
+        cleanupLayerInteractionHandlers = () => {
+          map.off('click', mapClickHandler);
+          map.off('mousemove', mapMouseMoveHandler);
+        };
 
         if (map.getLayer(addressLabelLayerId)) {
           map.moveLayer(addressLabelLayerId);
@@ -1739,6 +1795,7 @@ export function MapBuildingsLayer({
     return () => {
       map.off('idle', onIdle);
       map.off('style.load', onStyleLoad);
+      cleanupLayerInteractionHandlers?.();
     };
   }, [map, features, zoomLevel, onBuildingClick, statusFilters, campaignId, supabase, onAddToCRM, showOrphans, showAddressLabels, footprintStatusColors, addressStateOverrides]);
 


### PR DESCRIPTION
## What this does
Fixes a class of crashes on the campaign detail page where Mapbox's 
internal layer-scoped event machinery called queryRenderedFeatures 
during style transitions, throwing "Cannot read properties of undefined 
(reading 'getOwnLayer')" before any application code ran.

## Root cause
Layer-scoped listeners (map.on('click', LAYER_ID, ...), 
map.on('mouseenter', LAYER_ID, ...)) cause Mapbox to internally query 
the layer registry on every relevant interaction. If a style transition 
is in progress at that moment, the registry is temporarily unavailable 
and Mapbox throws. No application-level guard can prevent this because 
the crash happens inside Mapbox before the callback is invoked.

## Changes

**components/campaigns/CampaignDetailMapView.tsx**
- Converted point overlay circle layer-scoped click to guarded 
  map-level click with queryRenderedFeatures
- Converted parcel fill layer-scoped click to guarded map-level click

**components/map/MapBuildingsLayer.tsx**
- Converted PMTiles building layer click/hover listeners to guarded 
  map-level handlers
- Converted GeoJSON building and circle layer click/hover listeners 
  to guarded map-level handlers

**components/map/CampaignAddressPmtilesLayer.tsx**
- Converted address circle layer click/hover listeners to guarded 
  map-level click and mousemove handlers

All converted handlers follow the same pattern:
- map.isStyleLoaded() checked first
- map.getLayer() and map.queryRenderedFeatures() wrapped in try/catch
- Handler references stored for proper cleanup with map.off()

## Verified locally
- npx tsc --noEmit: clean
- npm run build: 0 errors
- Parcels layer active + double-click: no crash
- Mouse movement over map: no crash
- No layer-scoped click/mouseenter/mouseleave listeners remain in 
  the three changed files