### PR TITLE
fix: restore map interactivity — default style fallbacks and clean container teardown

### DIFF
--- a/components/campaigns/CampaignDetailMapView.tsx
+++ b/components/campaigns/CampaignDetailMapView.tsx
@@ -1012,6 +1012,14 @@ export function CampaignDetailMapView({
       if (mapInstance) {
         removeMapboxMapWhenSafe(mapInstance);
       }
+      // Synchronously clear any remaining Mapbox DOM from the container.
+      // removeMapboxMapWhenSafe may defer map.remove() if the map is not
+      // yet loaded. If the effect re-runs before removal completes, a new
+      // map would initialize into a dirty container, breaking interactivity.
+      // Clearing the container here ensures the next map always starts clean.
+      if (mapContainer.current) {
+        mapContainer.current.innerHTML = '';
+      }
       if (initAttemptedRef.current) {
         initAttemptedRef.current = false;
         setMapLoaded(false);

--- a/lib/map-styles.ts
+++ b/lib/map-styles.ts
@@ -33,13 +33,13 @@ export const MAP_STYLE_PRESET_META: Record<
 };
 
 const STANDARD_V12_STYLES: Record<Theme, string> = {
-  light: process.env.NEXT_PUBLIC_MAPBOX_STYLE_ID_STANDARD_LIGHT ?? '',
-  dark: process.env.NEXT_PUBLIC_MAPBOX_STYLE_ID_STANDARD_DARK ?? '',
+  light: process.env.NEXT_PUBLIC_MAPBOX_STYLE_ID_STANDARD_LIGHT || 'mapbox://styles/mapbox/streets-v12',
+  dark: process.env.NEXT_PUBLIC_MAPBOX_STYLE_ID_STANDARD_DARK || 'mapbox://styles/mapbox/dark-v11',
 };
 
 const STANDARD_V11_STYLES: Record<Theme, string> = {
-  light: process.env.NEXT_PUBLIC_MAPBOX_STYLE_ID_LEGACY_LIGHT ?? '',
-  dark: process.env.NEXT_PUBLIC_MAPBOX_STYLE_ID_LEGACY_DARK ?? '',
+  light: process.env.NEXT_PUBLIC_MAPBOX_STYLE_ID_LEGACY_LIGHT || 'mapbox://styles/mapbox/streets-v12',
+  dark: process.env.NEXT_PUBLIC_MAPBOX_STYLE_ID_LEGACY_DARK || 'mapbox://styles/mapbox/dark-v11',
 };
 
 const strippedStyleCache = new Map<string, Record<string, unknown>>();


### PR DESCRIPTION
## What this does
Fixes the campaign detail map being completely non-interactive 
(unable to drag or zoom). The map now loads correctly, zooms to 
the campaign area, and shows individual buildings.

## Root cause — two separate issues

**1. Missing style fallbacks (primary cause)**
When NEXT_PUBLIC_MAPBOX_STYLE_ID_LEGACY_LIGHT and 
NEXT_PUBLIC_MAPBOX_STYLE_ID_LEGACY_DARK are not set, 
lib/map-styles.ts resolved to an empty string. Mapbox received 
style: '' and could not load any style, resulting in a blank 
non-interactive canvas. Mapbox warned: "There is no style added 
to the map."

Fixed by adding standard Mapbox public style fallbacks:
- Light: mapbox://styles/mapbox/streets-v12
- Dark: mapbox://styles/mapbox/dark-v11

These are always available, always contain the composite source, 
and work without custom credentials.

**2. Dirty container on reinit (secondary cause)**
removeMapboxMapWhenSafe() defers map.remove() if the map is not 
yet loaded, but map.current was set to null immediately. If the 
effect re-ran before removal completed, a new map initialized into 
a container still containing the previous map's DOM. Mapbox warns 
this negatively impacts interactivity.

Fixed by synchronously clearing mapContainer.current.innerHTML 
after removeMapboxMapWhenSafe() in the cleanup function.

## Changes
- **lib/map-styles.ts** — fallback to streets-v12/dark-v11 when 
  style env vars are not set
- **components/campaigns/CampaignDetailMapView.tsx** — synchronously 
  clear map container DOM in useEffect cleanup

## Verified locally
- Map is fully interactive (drag, zoom, click)
- Map auto-centers on campaign area
- Individual buildings visible
- npx tsc --noEmit: clean
- npm run build: 0 errors

## Note
Campaign buildings are not yet highlighted because the diamond/
PMTiles build webhooks are not configured locally 
(DIAMOND_BUILD_WEBHOOK_URL). This is expected, the map works 
correctly in production where those webhooks are configured.