### PR TITLE
fix: Mapbox layer crash guards, TS2344 route export, and map-bundle RPC timeout for Bedrock campaigns

### DIFF
--- a/app/api/campaigns/[campaignId]/addresses/route.ts
+++ b/app/api/campaigns/[campaignId]/addresses/route.ts
@@ -263,7 +263,7 @@ async function fetchPmtilesAddressFeatures(campaignId: string) {
   return Array.from(byId.values());
 }
 
-export function parsePointGeometry(address: Record<string, unknown>): PointGeometry | null {
+function parsePointGeometry(address: Record<string, unknown>): PointGeometry | null {
   // NEW: Check for 'geom_json' field first (from Supabase view with ST_AsGeoJSON conversion)
   if (address.geom_json) {
     const geomJson = address.geom_json;

--- a/components/map/CampaignAddressPmtilesLayer.tsx
+++ b/components/map/CampaignAddressPmtilesLayer.tsx
@@ -730,20 +730,57 @@ export function CampaignAddressPmtilesLayer({
         map.getCanvas().style.cursor = '';
       };
 
-      map.on('click', CIRCLE_LAYER_ID, clickHandler);
-      map.on('click', GLOW_LAYER_ID, clickHandler);
-      map.on('mouseenter', CIRCLE_LAYER_ID, enterHandler);
-      map.on('mouseenter', GLOW_LAYER_ID, enterHandler);
-      map.on('mouseleave', CIRCLE_LAYER_ID, leaveHandler);
-      map.on('mouseleave', GLOW_LAYER_ID, leaveHandler);
+      const getInteractiveLayers = () => {
+        const layers: string[] = [];
+        try {
+          if (!map.isStyleLoaded()) return layers;
+          if (map.getLayer(CIRCLE_LAYER_ID)) layers.push(CIRCLE_LAYER_ID);
+          if (map.getLayer(GLOW_LAYER_ID)) layers.push(GLOW_LAYER_ID);
+        } catch {
+          return [];
+        }
+        return layers;
+      };
+
+      // Use map-level handlers so Mapbox does not run layer-scoped
+      // queryRenderedFeatures internally during style transitions.
+      const mapClickHandler = (event: mapboxgl.MapMouseEvent) => {
+        try {
+          const layers = getInteractiveLayers();
+          if (layers.length === 0) return;
+          const features = map.queryRenderedFeatures(event.point, { layers });
+          if (features.length > 0) clickHandler(Object.assign(event, { features }));
+        } catch {
+          return;
+        }
+      };
+
+      // Use map-level mousemove so hover does not depend on Mapbox's
+      // layer-scoped mouseenter/mouseleave dispatch during style transitions.
+      const mapMouseMoveHandler = (event: mapboxgl.MapMouseEvent) => {
+        try {
+          const layers = getInteractiveLayers();
+          if (layers.length === 0) {
+            leaveHandler();
+            return;
+          }
+          const features = map.queryRenderedFeatures(event.point, { layers });
+          if (features.length > 0) {
+            enterHandler();
+          } else {
+            leaveHandler();
+          }
+        } catch {
+          leaveHandler();
+        }
+      };
+
+      map.on('click', mapClickHandler);
+      map.on('mousemove', mapMouseMoveHandler);
 
       return () => {
-        map.off('click', CIRCLE_LAYER_ID, clickHandler);
-        map.off('click', GLOW_LAYER_ID, clickHandler);
-        map.off('mouseenter', CIRCLE_LAYER_ID, enterHandler);
-        map.off('mouseenter', GLOW_LAYER_ID, enterHandler);
-        map.off('mouseleave', CIRCLE_LAYER_ID, leaveHandler);
-        map.off('mouseleave', GLOW_LAYER_ID, leaveHandler);
+        map.off('click', mapClickHandler);
+        map.off('mousemove', mapMouseMoveHandler);
       };
     };
 

--- a/components/map/MapBuildingsLayer.tsx
+++ b/components/map/MapBuildingsLayer.tsx
@@ -1115,40 +1115,26 @@ export function MapBuildingsLayer({
 
     // Remove layers if zoomed out too far
     if (zoom < 12) {
-      if (map.getLayer(layerId)) {
-        try {
+      // map.getLayer can throw while Mapbox is rebuilding the style layer registry.
+      try {
+        if (!map.isStyleLoaded()) return;
+        if (map.getLayer(layerId)) {
           map.removeLayer(layerId);
-        } catch (err) {
-          // Layer might not exist
         }
-      }
-      if (map.getLayer(leadGlowLayerId)) {
-        try {
+        if (map.getLayer(leadGlowLayerId)) {
           map.removeLayer(leadGlowLayerId);
-        } catch (err) {
-          // Layer might not exist
         }
-      }
-      if (map.getLayer(circleLayerId)) {
-        try {
+        if (map.getLayer(circleLayerId)) {
           map.removeLayer(circleLayerId);
-        } catch (err) {
-          // Layer might not exist
         }
-      }
-      if (map.getLayer(circleLeadGlowLayerId)) {
-        try {
+        if (map.getLayer(circleLeadGlowLayerId)) {
           map.removeLayer(circleLeadGlowLayerId);
-        } catch (err) {
-          // Layer might not exist
         }
-      }
-      if (map.getLayer(shadowLayerId)) {
-        try {
+        if (map.getLayer(shadowLayerId)) {
           map.removeLayer(shadowLayerId);
-        } catch (err) {
-          // Layer might not exist
         }
+      } catch {
+        return;
       }
     }
   }, [map, circleLayerId]);
@@ -1164,40 +1150,26 @@ export function MapBuildingsLayer({
     // Only fetch if zoomed in enough (zoom >= 12 for better visibility)
     if (zoom < 12) {
       // Remove layers if zoomed out too far
-      if (map.getLayer(layerId)) {
-        try {
+      // map.getLayer can throw while Mapbox is rebuilding the style layer registry.
+      try {
+        if (!map.isStyleLoaded()) return;
+        if (map.getLayer(layerId)) {
           map.removeLayer(layerId);
-        } catch (err) {
-          // Layer might not exist
         }
-      }
-      if (map.getLayer(leadGlowLayerId)) {
-        try {
+        if (map.getLayer(leadGlowLayerId)) {
           map.removeLayer(leadGlowLayerId);
-        } catch (err) {
-          // Layer might not exist
         }
-      }
-      if (map.getLayer(circleLayerId)) {
-        try {
+        if (map.getLayer(circleLayerId)) {
           map.removeLayer(circleLayerId);
-        } catch (err) {
-          // Layer might not exist
         }
-      }
-      if (map.getLayer(circleLeadGlowLayerId)) {
-        try {
+        if (map.getLayer(circleLeadGlowLayerId)) {
           map.removeLayer(circleLeadGlowLayerId);
-        } catch (err) {
-          // Layer might not exist
         }
-      }
-      if (map.getLayer(shadowLayerId)) {
-        try {
+        if (map.getLayer(shadowLayerId)) {
           map.removeLayer(shadowLayerId);
-        } catch (err) {
-          // Layer might not exist
         }
+      } catch {
+        return;
       }
       return;
     }
@@ -1778,8 +1750,17 @@ export function MapBuildingsLayer({
         }
       }
 
+      // map.getLayer can throw during style transitions even after an earlier style-loaded check.
+      let hasBuildingLayer = false;
+      try {
+        if (!map.isStyleLoaded()) return;
+        hasBuildingLayer = Boolean(map.getLayer(layerId));
+      } catch {
+        return;
+      }
+
       // Add or update fill-extrusion layer (for Polygon/MultiPolygon geometries)
-      if (!map.getLayer(layerId)) {
+      if (!hasBuildingLayer) {
         try {
           // NOTE: Shadow layer removed to fix "dark square" visual artifact
           // The 3D fill-extrusion with proper lighting provides sufficient visual depth

--- a/supabase/migrations/20260514120000_skip_building_rpc_for_bedrock_campaigns.sql
+++ b/supabase/migrations/20260514120000_skip_building_rpc_for_bedrock_campaigns.sql
@@ -1,0 +1,157 @@
+-- Skip legacy building aggregation in rpc_get_campaign_map_bundle for
+-- Diamond/Bedrock-provisioned campaigns.
+--
+-- The legacy Gold building RPC, rpc_get_campaign_full_features, can scan
+-- ref_buildings_gold by campaign territory and build inline GeoJSON. That is
+-- appropriate for legacy Gold/Silver database-backed campaigns, but it times
+-- out for Bedrock campaigns whose buildings are produced as PMTiles artifacts.
+-- Diamond/Bedrock buildings are rendered through the frontend manifest path
+-- and PMTiles artifacts instead of this bundle RPC.
+--
+-- This migration updates only rpc_get_campaign_map_bundle. It does not change
+-- rpc_get_campaign_full_features or get_campaign_buildings_geojson, which are
+-- still used by legacy callers and iOS-coupled paths.
+
+CREATE OR REPLACE FUNCTION public.rpc_get_campaign_map_bundle(p_campaign_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_campaign record;
+  v_addresses jsonb := jsonb_build_object('type', 'FeatureCollection', 'features', '[]'::jsonb);
+  v_buildings jsonb := jsonb_build_object('type', 'FeatureCollection', 'features', '[]'::jsonb);
+  v_parcels jsonb := jsonb_build_object('type', 'FeatureCollection', 'features', '[]'::jsonb);
+  v_roads jsonb := jsonb_build_object('type', 'FeatureCollection', 'features', '[]'::jsonb);
+  v_address_count integer := 0;
+  v_building_count integer := 0;
+  v_parcel_count integer := 0;
+  v_road_count integer := 0;
+  v_updated_at timestamptz;
+BEGIN
+  SELECT
+    c.id,
+    c.provision_status,
+    c.provision_phase,
+    c.provision_source,
+    c.region,
+    c.updated_at,
+    c.addresses_ready_at,
+    c.map_ready_at,
+    c.optimized_at
+  INTO v_campaign
+  FROM public.campaigns c
+  WHERE c.id = p_campaign_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'campaign_id', p_campaign_id,
+      'status', 'not_found',
+      'phase', 'not_found',
+      'map_ready', false,
+      'addresses', v_addresses,
+      'buildings', v_buildings,
+      'parcels', v_parcels,
+      'roads', v_roads,
+      'counts', jsonb_build_object('addresses', 0, 'buildings', 0, 'parcels', 0, 'roads', 0),
+      'updated_at', now()
+    );
+  END IF;
+
+  BEGIN
+    v_addresses := COALESCE(public.rpc_get_campaign_addresses(p_campaign_id), v_addresses);
+  EXCEPTION WHEN OTHERS THEN
+    v_addresses := jsonb_build_object('type', 'FeatureCollection', 'features', '[]'::jsonb);
+  END;
+
+  IF v_campaign.provision_source NOT IN (
+    'diamond', 'bedrock_ca', 'bedrock_us', 'bedrock_au',
+    'bedrock_nz', 'bedrock_za', 'bedrock_uk'
+  ) THEN
+    -- Only run Gold building RPC for legacy provision sources.
+    BEGIN
+      v_buildings := COALESCE(
+        public.rpc_get_campaign_full_features(p_campaign_id),
+        v_buildings
+      );
+      IF v_buildings IS NULL THEN
+        v_buildings := COALESCE(
+          public.get_campaign_buildings_geojson(p_campaign_id),
+          v_buildings
+        );
+      END IF;
+    EXCEPTION WHEN OTHERS THEN
+      BEGIN
+        v_buildings := COALESCE(
+          public.get_campaign_buildings_geojson(p_campaign_id),
+          v_buildings
+        );
+      EXCEPTION WHEN OTHERS THEN
+        v_buildings := jsonb_build_object('type', 'FeatureCollection', 'features', '[]'::jsonb);
+      END;
+    END;
+  END IF;
+  -- For diamond/bedrock_* campaigns, buildings come from PMTiles artifacts
+  -- via the frontend fallback (MapBuildingsLayer manifest path). Skipping the
+  -- Gold building RPC here prevents statement timeouts on
+  -- rpc_get_campaign_full_features for these campaigns.
+
+  BEGIN
+    v_parcels := COALESCE(public.rpc_get_campaign_parcels(p_campaign_id), v_parcels);
+  EXCEPTION WHEN OTHERS THEN
+    v_parcels := jsonb_build_object('type', 'FeatureCollection', 'features', '[]'::jsonb);
+  END;
+
+  BEGIN
+    v_roads := COALESCE(public.rpc_get_campaign_roads_v2(p_campaign_id), v_roads);
+  EXCEPTION WHEN OTHERS THEN
+    v_roads := jsonb_build_object('type', 'FeatureCollection', 'features', '[]'::jsonb);
+  END;
+
+  v_address_count := COALESCE(jsonb_array_length(v_addresses->'features'), 0);
+  v_building_count := COALESCE(jsonb_array_length(v_buildings->'features'), 0);
+  v_parcel_count := COALESCE(jsonb_array_length(v_parcels->'features'), 0);
+  v_road_count := COALESCE(jsonb_array_length(v_roads->'features'), 0);
+
+  SELECT GREATEST(
+    COALESCE(v_campaign.updated_at, '-infinity'::timestamptz),
+    COALESCE(v_campaign.addresses_ready_at, '-infinity'::timestamptz),
+    COALESCE(v_campaign.map_ready_at, '-infinity'::timestamptz),
+    COALESCE(v_campaign.optimized_at, '-infinity'::timestamptz),
+    COALESCE((SELECT max(ca.created_at) FROM public.campaign_addresses ca WHERE ca.campaign_id = p_campaign_id), '-infinity'::timestamptz),
+    COALESCE((SELECT max(cp.created_at) FROM public.campaign_parcels cp WHERE cp.campaign_id = p_campaign_id), '-infinity'::timestamptz)
+  )
+  INTO v_updated_at;
+
+  IF v_updated_at = '-infinity'::timestamptz THEN
+    v_updated_at := now();
+  END IF;
+
+  RETURN jsonb_build_object(
+    'campaign_id', p_campaign_id,
+    'status', COALESCE(v_campaign.provision_status::text, 'pending'),
+    'phase', COALESCE(v_campaign.provision_phase::text, v_campaign.provision_status::text, 'pending'),
+    'source', COALESCE(v_campaign.provision_source::text, 'unknown'),
+    'region', v_campaign.region,
+    'map_ready', v_address_count > 0 AND (v_building_count > 0 OR v_parcel_count > 0 OR COALESCE(v_campaign.map_ready_at, v_campaign.optimized_at) IS NOT NULL),
+    'addresses', v_addresses,
+    'buildings', v_buildings,
+    'parcels', v_parcels,
+    'roads', v_roads,
+    'counts', jsonb_build_object(
+      'addresses', v_address_count,
+      'buildings', v_building_count,
+      'parcels', v_parcel_count,
+      'roads', v_road_count
+    ),
+    'updated_at', v_updated_at
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_get_campaign_map_bundle(uuid) TO authenticated, anon, service_role;
+
+COMMENT ON FUNCTION public.rpc_get_campaign_map_bundle(uuid) IS
+'Unified campaign map bundle for web and iOS. Returns normalized GeoJSON FeatureCollections for addresses, buildings, parcels, and roads regardless of Diamond or Bedrock source.';


### PR DESCRIPTION
## What this does
Four targeted fixes following the merge of the Bedrock/Diamond 
branch into main. The merge introduced new unguarded Mapbox event 
listeners and a TypeScript violation, and exposed a database timeout 
that was breaking the campaign detail map for all Bedrock-provisioned 
campaigns.

## Changes

**components/map/CampaignAddressPmtilesLayer.tsx**
The address layer rewrite added layer-scoped click, mouseenter, and 
mouseleave listeners for CIRCLE_LAYER_ID and GLOW_LAYER_ID. These 
cause Mapbox to internally call queryRenderedFeatures during style 
transitions, throwing "Cannot read properties of undefined (reading 
'getOwnLayer')". Converted to guarded map-level handlers, same 
pattern established across the map components in the previous PRs.

**components/map/MapBuildingsLayer.tsx**
The building layer expansion added unguarded map.getLayer() calls 
in zoom and removal paths. Wrapped each in isStyleLoaded() guard 
and try/catch to prevent crashes during style transitions.

**app/api/campaigns/[campaignId]/addresses/route.ts**
parsePointGeometry was exported from a Next.js route file. Route 
files may only export HTTP method handlers, exporting utilities 
causes TS2344 in generated types. Removed the export keyword. 
Nothing imports this function from outside the route file.

**supabase/migrations/20260514120000_skip_building_rpc_for_bedrock_campaigns.sql**
rpc_get_campaign_map_bundle was calling rpc_get_campaign_full_features 
for all campaigns. That function scans ref_buildings_gold by territory 
intersection, appropriate for legacy Gold campaigns, but it times out 
at 8 seconds for Bedrock campaigns whose buildings come from PMTiles 
artifacts on S3, not the Gold database. The result was a 500 on every 
map-bundle request for every Bedrock campaign, preventing the campaign 
detail map from loading.

Fixed by skipping the Gold building RPC in rpc_get_campaign_map_bundle 
when provision_source is diamond, bedrock_ca, bedrock_us, bedrock_au, 
bedrock_nz, bedrock_za, or bedrock_uk. Buildings for these campaigns 
are served through the frontend MapBuildingsLayer manifest path.

rpc_get_campaign_full_features itself is unchanged — still used by 
/api/buildings, iOS map routes, and scripts.

Applied to production. map-bundle now returns 200 in ~2s for Bedrock 
campaigns (was timing out at 8s with error 57014).

## Verified locally
- npx tsc --noEmit: 0 errors
- npm run build: 0 errors
- Campaign creation: 500 addresses, 252 buildings, 96% match rate
- map-bundle: 200 in ~2s
- QR export: 294 PNGs, CSV manifest populated
- Map interactions: no crashes on hover, click, or double-click