### PR TITLE
fix: resolve all ESLint errors and remove unused imports

### DIFF
--- a/app/api/ai/flyer/route.ts
+++ b/app/api/ai/flyer/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { FlyerTemplate, FlyerListingData } from "@/types/flyer";
+import { FlyerTemplate } from "@/types/flyer";
 
 const GEMINI_MODEL = "gemini-2.5-flash";
 

--- a/app/api/campaigns/[campaignId]/buildings/[buildingId]/address-candidates/route.ts
+++ b/app/api/campaigns/[campaignId]/buildings/[buildingId]/address-candidates/route.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { NextResponse } from "next/server";
 import { getSupabaseUrl } from "@/lib/supabase/env";
 
@@ -203,7 +203,7 @@ function round(value: number, places = 1): number {
   return Math.round(value * factor) / factor;
 }
 
-async function ensureCampaignAccess(supabase: any, campaignId: string, userId: string): Promise<boolean> {
+async function ensureCampaignAccess(supabase: SupabaseClient, campaignId: string, userId: string): Promise<boolean> {
   const { data: campaign, error } = await supabase
     .from("campaigns")
     .select("id, owner_id, workspace_id")
@@ -231,7 +231,7 @@ async function ensureCampaignAccess(supabase: any, campaignId: string, userId: s
   return Boolean(campaignMember);
 }
 
-async function resolveBuilding(supabase: any, campaignId: string, buildingIdParam: string): Promise<ResolvedBuilding | null> {
+async function resolveBuilding(supabase: SupabaseClient, campaignId: string, buildingIdParam: string): Promise<ResolvedBuilding | null> {
   const buildingQuery = supabase
     .from("buildings")
     .select("id, gers_id, geom, addr_street, house_name")
@@ -260,7 +260,7 @@ async function resolveBuilding(supabase: any, campaignId: string, buildingIdPara
     .eq("id", buildingIdParam)
     .maybeSingle();
   const geometry = goldRow ? parseGeometry(goldRow.geom) : null;
-  return geometry ? {
+  return goldRow && geometry ? {
     rowId: null,
     publicId: goldRow.id,
     geometry,

--- a/app/api/campaigns/[campaignId]/orphans/route.ts
+++ b/app/api/campaigns/[campaignId]/orphans/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseServerClient } from '@/lib/supabase/server';
-import { StableLinkerService } from '@/lib/services/StableLinkerService';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/app/api/campaigns/[campaignId]/split-errors/route.ts
+++ b/app/api/campaigns/[campaignId]/split-errors/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseServerClient } from '@/lib/supabase/server';
-import { TownhouseSplitterService } from '@/lib/services/TownhouseSplitterService';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/app/api/campaigns/[campaignId]/units/route.ts
+++ b/app/api/campaigns/[campaignId]/units/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseServerClient } from '@/lib/supabase/server';
-import { TownhouseSplitterService } from '@/lib/services/TownhouseSplitterService';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/app/api/flyers/[flyerId]/export/route.ts
+++ b/app/api/flyers/[flyerId]/export/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createAdminClient } from '@/lib/supabase/server';
 
 /**
  * Export Flyer API Route
@@ -61,7 +60,6 @@ export async function POST(
     );
   }
 }
-
 
 
 

--- a/app/api/mapbox/tilequery-buildings/route.ts
+++ b/app/api/mapbox/tilequery-buildings/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createAdminClient } from '@/lib/supabase/server';
 
 export async function POST(request: NextRequest) {
   try {
@@ -52,4 +51,3 @@ export async function POST(request: NextRequest) {
     );
   }
 }
-

--- a/app/farms/[id]/page.tsx
+++ b/app/farms/[id]/page.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
 import {
-  Activity,
   BarChart3,
   CalendarDays,
   CheckCircle2,

--- a/components/CreateHubView.tsx
+++ b/components/CreateHubView.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   Dialog,

--- a/components/address/AddressAutocomplete.tsx
+++ b/components/address/AddressAutocomplete.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { Input } from '@/components/ui/input';
 import { MapPin, Loader2 } from 'lucide-react';
 import debounce from 'lodash.debounce';

--- a/components/map/RouteLayer.tsx
+++ b/components/map/RouteLayer.tsx
@@ -10,7 +10,6 @@ import {
   Navigation, 
   Clock, 
   Footprints, 
-  MapPin, 
   ChevronDown, 
   ChevronUp,
   Route,

--- a/components/map/ThreeHouseLayer.tsx
+++ b/components/map/ThreeHouseLayer.tsx
@@ -4,7 +4,6 @@ import * as THREE from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import type { Map as MapboxMap } from 'mapbox-gl';
 import mapboxgl from 'mapbox-gl';
-import * as turf from '@turf/turf';
 import type { BuildingModelPoint } from '@/lib/services/MapService';
 import { MapService } from '@/lib/services/MapService';
 import type { BuildingStatus } from '@/types/database';

--- a/lib/editor-canva/features/editor/components/footer.tsx
+++ b/lib/editor-canva/features/editor/components/footer.tsx
@@ -2,10 +2,8 @@
 
 import { useState, useEffect } from "react";
 import { 
-  Minimize, 
   ZoomIn, 
   ZoomOut, 
-  Grid3x3, 
   Maximize, 
   HelpCircle,
   LayoutGrid

--- a/lib/editor-canva/features/editor/components/image-sidebar.tsx
+++ b/lib/editor-canva/features/editor/components/image-sidebar.tsx
@@ -1,6 +1,5 @@
-import Image from "next/image";
 import Link from "next/link";
-import { AlertTriangle, Loader, Upload } from "lucide-react";
+import { AlertTriangle, Loader } from "lucide-react";
 
 import { ActiveTool, Editor } from "@/lib/editor-canva/features/editor/types";
 import { ToolSidebarClose } from "@/lib/editor-canva/features/editor/components/tool-sidebar-close";

--- a/lib/editor-canva/features/editor/components/layers-sidebar.tsx
+++ b/lib/editor-canva/features/editor/components/layers-sidebar.tsx
@@ -7,7 +7,6 @@ import { ActiveTool, Editor } from "@/lib/editor-canva/features/editor/types";
 import { ToolSidebarClose } from "@/lib/editor-canva/features/editor/components/tool-sidebar-close";
 import { ToolSidebarHeader } from "@/lib/editor-canva/features/editor/components/tool-sidebar-header";
 import { cn } from "@/lib/editor-canva/lib/utils";
-import { Button } from "@/lib/editor-canva/components/ui/button";
 import { ScrollArea } from "@/lib/editor-canva/components/ui/scroll-area";
 import {
   DndContext,
@@ -19,7 +18,6 @@ import {
   DragEndEvent,
 } from '@dnd-kit/core';
 import {
-  arrayMove,
   SortableContext,
   sortableKeyboardCoordinates,
   useSortable,

--- a/lib/editor-canva/features/editor/components/navbar.tsx
+++ b/lib/editor-canva/features/editor/components/navbar.tsx
@@ -13,8 +13,7 @@ import {
   Undo2,
   Crop,
   Square,
-  Menu,
-  Maximize2
+  Menu
 } from "lucide-react";
 
 import { UserButton } from "@/lib/editor-canva/features/auth/components/user-button";

--- a/lib/editor-canva/features/editor/components/resource-links.tsx
+++ b/lib/editor-canva/features/editor/components/resource-links.tsx
@@ -2,7 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { CheckCircle2, Circle, Loader2, Megaphone, Globe, QrCode } from "lucide-react";
+import { CheckCircle2, Loader2, Megaphone, Globe, QrCode } from "lucide-react";
 import { Button } from "@/lib/editor-canva/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/lib/editor-canva/components/ui/tooltip";
 import { cn } from "@/lib/editor-canva/lib/utils";
@@ -165,4 +165,3 @@ export const ResourceLinks = ({ projectId }: ResourceLinksProps) => {
     </TooltipProvider>
   );
 };
-

--- a/lib/editor-canva/features/editor/components/uploads-sidebar.tsx
+++ b/lib/editor-canva/features/editor/components/uploads-sidebar.tsx
@@ -4,7 +4,6 @@ import Image from "next/image";
 import { AlertTriangle, Loader, Upload } from "lucide-react";
 
 import { ActiveTool, Editor } from "@/lib/editor-canva/features/editor/types";
-import { ToolSidebarClose } from "@/lib/editor-canva/features/editor/components/tool-sidebar-close";
 import { ToolSidebarHeader } from "@/lib/editor-canva/features/editor/components/tool-sidebar-header";
 
 import { useGetImages } from "@/lib/editor-canva/features/images/api/use-get-images";
@@ -113,5 +112,4 @@ export const UploadsSidebar = ({ editor, activeTool, onChangeActiveTool }: Uploa
     </aside>
   );
 };
-
 

--- a/lib/editor/konvaHelpers.ts
+++ b/lib/editor/konvaHelpers.ts
@@ -4,7 +4,6 @@
  * Utilities for working with Konva objects, hit detection, and coordinate conversion.
  */
 
-import type Konva from 'konva';
 import type { EditorElement } from './types';
 
 /**
@@ -128,7 +127,6 @@ export function isInputElement(target: EventTarget | null): boolean {
   
   return isInput || isContentEditable;
 }
-
 
 
 

--- a/lib/editor/state.ts
+++ b/lib/editor/state.ts
@@ -9,7 +9,6 @@ import type {
   EditorState,
   EditorElement,
   EditorPage,
-  EditorStateSnapshot,
 } from './types';
 import {
   createSnapshot,
@@ -586,5 +585,4 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
     set(getInitialEditorState());
   },
 }));
-
 

--- a/lib/flyers/aiTemplateConverter.ts
+++ b/lib/flyers/aiTemplateConverter.ts
@@ -4,7 +4,7 @@
  * Converts AI-generated FlyerTemplate to database FlyerData format
  */
 
-import type { FlyerTemplate, FlyerElement } from '@/types/flyer';
+import type { FlyerTemplate } from '@/types/flyer';
 import type { FlyerData, FlyerElement as DbFlyerElement } from '@/lib/flyers/types';
 import { generateId } from '@/lib/editor/utils';
 
@@ -104,4 +104,3 @@ export function convertAITemplateToFlyerData(
     elements,
   };
 }
-

--- a/lib/services/BuildingService.ts
+++ b/lib/services/BuildingService.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@/lib/supabase/client';
 import type { Building, BuildingInteraction, BuildingStatus } from '@/types/database';
 import * as turf from '@turf/turf';
-import type { Feature, LineString, MultiPolygon, Point, Polygon } from 'geojson';
+import type { Feature, LineString, Point } from 'geojson';
 
 export interface HouseOrientation {
   houseBearing: number; // Bearing from centroid to nearest point on road (0-360)


### PR DESCRIPTION
## What this does
Clears all ESLint errors and removes dead import specifiers introduced 
or carried forward across the Bedrock/Diamond merge. The codebase now 
has 0 lint errors. Remaining 133 warnings are deferred, they require 
case-by-case review (exhaustive-deps in map hooks, no-img-element in 
email/editor contexts, unused callback params).

## Changes

**app/api/campaigns/[campaignId]/buildings/[buildingId]/address-candidates/route.ts**
Two functions used `supabase: any` as a parameter type, triggering 
@typescript-eslint/no-explicit-any errors. Imported SupabaseClient 
from @supabase/supabase-js and replaced both annotations with the 
correct type. Added one null narrowing for goldRow required by the 
stronger type. These were the only 2 ESLint errors in the codebase.

**21 files — unused import removals**
Removed 25 unused import specifiers identified by the ESLint 
no-unused-vars audit. Scope was limited strictly to import statements,
unused function parameters, state setters, and local variables were 
not touched as those require case-by-case review.

Files affected: app/api/ai/flyer/route.ts, app/api/campaigns/[campaignId]/orphans/route.ts, 
app/api/campaigns/[campaignId]/split-errors/route.ts, app/api/campaigns/[campaignId]/units/route.ts, 
app/api/flyers/[flyerId]/export/route.ts, app/api/mapbox/tilequery-buildings/route.ts, 
app/farms/[id]/page.tsx, components/CreateHubView.tsx, components/address/AddressAutocomplete.tsx, 
components/map/RouteLayer.tsx, components/map/ThreeHouseLayer.tsx, and 10 files under 
lib/editor-canva and lib/editor and lib/flyers and lib/services.

## Verified
- npx tsc --noEmit: 0 errors
- npm run build: 0 errors  
- npx eslint . --ext .ts,.tsx: 0 errors, 133 warnings
- ESLint delta: 160 problems → 133 problems, 2 errors → 0 errors