### PR TITLE
fix: QR cleanup, implement View QR button, document DIAMOND_BUILD_WEBHOOK_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,6 +134,7 @@ S3_BUCKET=
 # Local/self-hosted default. Production should point at a worker
 # with tippecanoe installed, or at /api/internal/diamond-build on
 # an environment that can safely run the builder command.
+# Queues Diamond/Bedrock PMTiles overlay builds; required to see map overlays locally.
 DIAMOND_BUILD_WEBHOOK_URL=http://localhost:3000/api/internal/diamond-build
 # Recommended in production. Generate with: openssl rand -hex 32
 DIAMOND_BUILD_WEBHOOK_SECRET=

--- a/app/api/campaigns/[campaignId]/vdp-manifest/route.ts
+++ b/app/api/campaigns/[campaignId]/vdp-manifest/route.ts
@@ -82,7 +82,6 @@ export async function GET(
         address,
         formatted,
         postal_code,
-        qr_png_url,
         purl,
         seq
       `)

--- a/components/RecipientsTable.tsx
+++ b/components/RecipientsTable.tsx
@@ -237,23 +237,18 @@ export function RecipientsTable({ recipients, campaignId, onRefresh }: Recipient
                           {loading === recipient.id ? 'Updating...' : 'Mark Attempted'}
                         </Button>
                       )}
-                      {/*
-                        TODO: This button never renders because qr_png_url is always passed
-                        as null from the campaign page (app/(main)/campaigns/[campaignId]/page.tsx).
-                        generate-qrs writes qr_code_base64 and purl, not qr_png_url.
-                        Future fix: either pass purl as a prop and link to it here,
-                        or implement a proper QR download button that uses qr_code_base64.
-                        See QR_SYSTEM.md Section 6 for full context.
-                      */}
-                      {recipient.qr_png_url && (
+                      {recipient.qr_code_base64 && (
                         <Button
                           size="sm"
                           variant="link"
-                          asChild
+                          onClick={() => {
+                            const base64Data = recipient.qr_code_base64?.replace(/^data:image\/\w+;base64,/, '');
+                            if (base64Data) {
+                              window.open(`data:image/png;base64,${base64Data}`, '_blank', 'noopener,noreferrer');
+                            }
+                          }}
                         >
-                          <a href={recipient.qr_png_url} target="_blank" rel="noopener noreferrer">
-                            View QR
-                          </a>
+                          View QR
                         </Button>
                       )}
                     </TableCell>


### PR DESCRIPTION
## What this does
Two QR cleanup tasks and one env documentation task.

## Changes

**app/api/campaigns/[campaignId]/vdp-manifest/route.ts**
Removed qr_png_url from the campaign_addresses select query. The column 
is always NULL — nothing writes to it. qr_code_base64 and purl are the 
live fields..

**components/RecipientsTable.tsx**
Replaced the dead View QR button and TODO comment block with a working 
implementation. Clicks open the QR image in a new tab as a PNG data URL 
decoded from qr_code_base64. Button only renders when qr_code_base64 
is non-null.

**.env.example**
Documented DIAMOND_BUILD_WEBHOOK_URL. Required for local map overlays — 
queues Diamond/Bedrock PMTiles overlay builds.

## Verified
- npx tsc --noEmit: 0 errors
- npm run build: 0 errors