### PR TITLE
fix: edge case fixes and automated tests from failure-hunting audit

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -43,6 +43,31 @@ and browser memory usage.
 An invalid domain in the URL constructor fails every address in the loop 
 but the route still returns success: true with count: 0.
 
+### Assignment notifications not deduplicated
+Repeated campaign assignment creation inserts repeated notification rows.
+No idempotency guard or dedup check exists in the assignments route.
+
+### notifications table has no FK on user_id
+The notifications table enforces workspace_id via FK but not user_id.
+The DB does not prevent notifications being created for non-existent users.
+
+### map-bundle: NULL provision_source skips Gold RPC silently
+In rpc_get_campaign_map_bundle, the building block is guarded by
+provision_source NOT IN (...). In PL/pgSQL, NULL NOT IN (...) evaluates
+to null, not true, so a never-provisioned campaign (provision_source = null)
+silently skips the Gold RPC and returns empty buildings with no error.
+
+### bundle.parcels unguarded if parcel view enabled
+In CampaignDetailMapView.tsx, bundle.parcels is accessed directly after
+response.json() without null/shape validation. SHOW_PARCEL_VIEW is
+currently false so this path is inactive, but enabling it could throw
+if the API returns null or a non-object.
+
+### useBuildingData: no dedup on repeated fallback queries
+If multiple fallback paths in useBuildingData return overlapping address
+IDs, the final address list may contain duplicates. No dedup step exists
+after the fallback chain resolves.
+
 ---
 
 ## Needs owner decision
@@ -68,6 +93,13 @@ Action: Daniel to confirm expected visibility behavior.
 Contact status resets after navigation in local dev. Needs 
 production verification before investigating further.
 
+### campaign territory_boundary not validated as valid Polygon
+The provision route checks if (!polygon) but does not validate that
+territory_boundary is actually a valid GeoJSON Polygon before passing
+it to Turf/PMTiles logic. A malformed non-null territory can pass
+validation and cause a cryptic failure inside Turf.
+Action: add explicit GeoJSON Polygon validation at the route boundary.
+
 ---
 
 ## Notes
@@ -75,3 +107,10 @@ production verification before investigating further.
 - Map initial center: fixed in PR 19 for campaigns with bbox/territory_boundary.
 - Notification insert schema mismatch (message vs body): fixed in PR 19.
 - View QR blank tab: fixed in PR 17/19.
+- isConnectionError timeout retry bug: fixed in PR 20. withTimeout()
+  rejection message 'exceeded' was not matched by the old check for
+  'timeout'. Timeout errors were never retried.
+- Building ID double-encoding bug: fixed in PR 20. IDs were only decoded
+  once, leaving double-encoded Bedrock IDs unresolved.
+- generate-qrs auth hole: fixed in PR 20. Route had no workspace check.
+- useBuildingData AbortController: fixed in PR 20.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -30,6 +30,19 @@ is not wired up. True async progress requires streaming or polling
 integration.
 Complexity: medium to large.
 
+### QR generation has no concurrent generation guard
+Two simultaneous generate-qrs calls for the same campaign race row-by-row.
+The final QR data is whichever request writes last.
+
+### Large QR payload risk
+QR PNGs are stored as base64 in campaign_addresses and passed through 
+the campaign page. Large campaigns can significantly inflate payload size 
+and browser memory usage.
+
+### generate-qrs invalid domain handling
+An invalid domain in the URL constructor fails every address in the loop 
+but the route still returns success: true with count: 0.
+
 ---
 
 ## Needs owner decision

--- a/app/api/campaigns/_utils/resolve-campaign-building.ts
+++ b/app/api/campaigns/_utils/resolve-campaign-building.ts
@@ -14,6 +14,20 @@ export function isUuid(value: string): boolean {
   return UUID_RE.test(value);
 }
 
+function decodeRoutePart(value: string): string {
+  let current = value;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      const decoded = decodeURIComponent(current);
+      if (decoded === current) return current;
+      current = decoded;
+    } catch {
+      return current;
+    }
+  }
+  return current;
+}
+
 /** Decode dynamic route params; rejoin segments when Overture ids were split on `/`. */
 export function normalizeBuildingRouteId(input: string | string[]): string {
   if (Array.isArray(input)) {
@@ -22,18 +36,21 @@ export function normalizeBuildingRouteId(input: string | string[]): string {
       input[0]?.toLowerCase() === 'overture' &&
       input[1]?.toLowerCase() === 'building'
     ) {
-      return `overture:building:${input.slice(2).map((part) => decodeURIComponent(part)).join(':')}`;
+      const rest = input
+        .slice(2)
+        .map((part) => decodeRoutePart(part))
+        .filter((part) => part.trim().length > 0);
+      return rest.length > 0 ? `overture:building:${rest.join(':')}` : '';
     }
-    return input.map((part) => decodeURIComponent(part)).join('/');
+    const parts = input
+      .map((part) => decodeRoutePart(part))
+      .filter((part) => part.trim().length > 0);
+    return parts.length > 0 ? parts.join('/') : '';
   }
 
   const trimmed = input.trim();
   if (!trimmed) return trimmed;
-  try {
-    return decodeURIComponent(trimmed);
-  } catch {
-    return trimmed;
-  }
+  return decodeRoutePart(trimmed);
 }
 
 /** All identifiers to try when resolving a map building id (e.g. overture:building:{uuid}). */

--- a/app/api/campaigns/provision/route.ts
+++ b/app/api/campaigns/provision/route.ts
@@ -30,6 +30,18 @@ import {
   CampaignMapModeService,
 } from '@/lib/services/CampaignMapModeService';
 import { isParcelRegionSupported } from '@/lib/geo/parcelRegions';
+import {
+  bboxFromPolygon,
+  buildAddressIdentity,
+  deduplicateAddressesByProvisionKey,
+  featureCollectionCount,
+  filterAddressesAgainstExisting,
+  isConnectionError,
+  isUniqueConstraintError,
+  provisionFailureReason,
+  shouldFailZeroAddressProvision,
+  snapshotHasStaticPmtilesGeometry,
+} from '@/lib/services/provisionHelpers';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -106,20 +118,6 @@ function staticGeometryAddressHydrationLimit() {
     : DEFAULT_STATIC_GEOMETRY_ADDRESS_HYDRATION_LIMIT;
 }
 
-function isConnectionError(error: Error): boolean {
-  return (
-    error.message.includes('closed') ||
-    error.message.includes('Connection Error') ||
-    error.message.includes('established') ||
-    error.message.includes('timeout')
-  );
-}
-
-function provisionFailureReason(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.trim().slice(0, 500) || 'Provisioning failed';
-}
-
 async function retryWithBackoff<T>(
   fn: () => Promise<T>,
   maxAttempts: number = 3,
@@ -168,79 +166,6 @@ function deduplicateAddresses(addresses: StandardCampaignAddress[]): StandardCam
   );
 }
 
-function normalizeAddressFragment(value: string | null | undefined): string {
-  return typeof value === 'string' ? value.trim().toLowerCase() : '';
-}
-
-function normalizeSource(value: string | null | undefined): string {
-  const normalized = normalizeAddressFragment(value);
-  return normalized || 'unknown';
-}
-
-function normalizeExternalAddressId(value: string | null | undefined): string {
-  return typeof value === 'string' ? value.trim() : '';
-}
-
-function externalAddressId(address: { gers_id?: string | null; source_id?: string | null }): string {
-  return normalizeExternalAddressId(address.gers_id ?? address.source_id);
-}
-
-function buildAddressSignature(address: {
-  formatted?: string | null;
-  house_number?: string | null;
-  street_name?: string | null;
-  locality?: string | null;
-  postal_code?: string | null;
-}): string {
-  const houseNumber = normalizeAddressFragment(address.house_number);
-  const streetName = normalizeAddressFragment(address.street_name);
-  const locality = normalizeAddressFragment(address.locality);
-  const postalCode = normalizeAddressFragment(address.postal_code);
-
-  if (houseNumber || streetName || locality) {
-    return `${houseNumber}|${streetName}|${locality}`;
-  }
-
-  const formatted = normalizeAddressFragment(address.formatted);
-  return `${formatted}|${postalCode}`;
-}
-
-function buildAddressIdentity(address: {
-  campaign_id: string;
-  formatted?: string | null;
-  house_number?: string | null;
-  street_name?: string | null;
-  locality?: string | null;
-  postal_code?: string | null;
-  source?: string | null;
-  source_id?: string | null;
-  gers_id?: string | null;
-}): string {
-  const source = normalizeSource(address.source);
-  const externalId = externalAddressId(address);
-  if (externalId) {
-    return `${address.campaign_id}|${source}|external|${externalId}`;
-  }
-
-  return `${address.campaign_id}|${source}|address|${buildAddressSignature(address)}`;
-}
-
-function deduplicateAddressesByProvisionKey(
-  addresses: StandardCampaignAddress[]
-): StandardCampaignAddress[] {
-  const deduped = new Map<string, StandardCampaignAddress>();
-
-  for (const address of addresses) {
-    const externalId = externalAddressId(address);
-    deduped.set(buildAddressIdentity(address), {
-      ...address,
-      gers_id: externalId || null,
-    });
-  }
-
-  return [...deduped.values()];
-}
-
 async function fetchCampaignAddressSignatures(
   supabase: ReturnType<typeof createAdminClient>,
   campaignId: string
@@ -271,85 +196,6 @@ async function fetchCampaignAddressSignatures(
   );
 }
 
-function filterAddressesAgainstExisting(
-  addresses: StandardCampaignAddress[],
-  existingSignatures: Set<string>
-): StandardCampaignAddress[] {
-  const accepted: StandardCampaignAddress[] = [];
-  const seenThisBatch = new Set<string>();
-
-  for (const address of addresses) {
-    const signature = buildAddressIdentity(address);
-    if (existingSignatures.has(signature) || seenThisBatch.has(signature)) {
-      continue;
-    }
-    seenThisBatch.add(signature);
-    accepted.push(address);
-  }
-
-  return accepted;
-}
-
-function isUniqueConstraintError(error: { message?: string; code?: string; details?: string } | null): boolean {
-  if (!error) {
-    return false;
-  }
-
-  const text = `${error.message ?? ''} ${error.details ?? ''}`.toLowerCase();
-  return error.code === '23505' || text.includes('unique') || text.includes('constraint') || text.includes('conflict');
-}
-
-function stringTileMetric(
-  metrics: Record<string, unknown> | null | undefined,
-  key: string
-): string | null {
-  const value = metrics?.[key];
-  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
-}
-
-function snapshotHasStaticPmtilesGeometry(
-  snapshot: LambdaSnapshotResponse | null | undefined
-): boolean {
-  if (!snapshot) return false;
-
-  const metrics = snapshot.metadata?.tile_metrics;
-  const buildingsKey = snapshot.s3_keys.buildings;
-  const addressesKey = snapshot.s3_keys.addresses;
-
-  return [
-    buildingsKey,
-    addressesKey,
-    stringTileMetric(metrics, 'pmtiles_key'),
-    stringTileMetric(metrics, 'addresses_pmtiles_key'),
-    stringTileMetric(metrics, 'parcels_pmtiles_key'),
-  ].some((key) => typeof key === 'string' && key.toLowerCase().endsWith('.pmtiles'));
-}
-
-function bboxFromPolygon(polygon: GeoJSON.Polygon): [number, number, number, number] | null {
-  const positions = polygon.coordinates.flat().filter(
-    (position): position is [number, number] =>
-      Array.isArray(position) &&
-      typeof position[0] === 'number' &&
-      typeof position[1] === 'number' &&
-      Number.isFinite(position[0]) &&
-      Number.isFinite(position[1])
-  );
-  if (positions.length === 0) return null;
-
-  let minLon = Infinity;
-  let minLat = Infinity;
-  let maxLon = -Infinity;
-  let maxLat = -Infinity;
-  for (const [lon, lat] of positions) {
-    minLon = Math.min(minLon, lon);
-    minLat = Math.min(minLat, lat);
-    maxLon = Math.max(maxLon, lon);
-    maxLat = Math.max(maxLat, lat);
-  }
-
-  return [minLon, minLat, maxLon, maxLat];
-}
-
 function lambdaSnapshotToCampaignSnapshotRow(snapshot: LambdaSnapshotResponse): CampaignSnapshotRow {
   return {
     bucket: snapshot.bucket,
@@ -362,12 +208,6 @@ function lambdaSnapshotToCampaignSnapshotRow(snapshot: LambdaSnapshotResponse): 
     created_at: null,
     tile_metrics: (snapshot.metadata?.tile_metrics ?? null) as Record<string, unknown> | null,
   };
-}
-
-function featureCollectionCount(value: unknown): number {
-  if (!value || typeof value !== 'object') return 0;
-  const features = (value as { features?: unknown }).features;
-  return Array.isArray(features) ? features.length : 0;
 }
 
 function snapshotWithScopedBuildingCount(
@@ -1343,7 +1183,7 @@ export async function POST(request: NextRequest) {
           }
 
           const hasStaticGeometry = snapshotHasStaticPmtilesGeometry(snapshot);
-          if (!hasResolvedAddresses && !hasStaticGeometry) {
+          if (shouldFailZeroAddressProvision({ hasResolvedAddresses, hasStaticGeometry })) {
             throw new ProvisionError(
               'Provisioning did not find any addresses in this territory. Try a larger polygon or a nearby area.',
               422

--- a/app/api/generate-qrs/route.ts
+++ b/app/api/generate-qrs/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import QRCode from 'qrcode';
-import { createAdminClient } from '@/lib/supabase/server';
+import { createAdminClient, getSupabaseServerClient } from '@/lib/supabase/server';
+import { ensureCampaignAccess } from '@/app/api/campaigns/_utils/access';
 import { createPrintableQrPng, formatAddressLabel } from '@/lib/utils/qr-print';
 
 function isLocalhostUrl(url: string): boolean {
@@ -28,8 +29,19 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Missing campaignId in request body' }, { status: 400 });
     }
 
+    const authClient = await getSupabaseServerClient();
+    const { data: { user } } = await authClient.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
     // Initialize Supabase Admin Client
     const supabase = createAdminClient();
+
+    const hasAccess = await ensureCampaignAccess(supabase, campaignId, user.id);
+    if (!hasAccess) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
 
     // ---------------------------------------------------------
     // 2. FETCH ADDRESSES

--- a/components/RecipientsTable.tsx
+++ b/components/RecipientsTable.tsx
@@ -242,16 +242,21 @@ export function RecipientsTable({ recipients, campaignId, onRefresh }: Recipient
                           size="sm"
                           variant="link"
                           onClick={() => {
-                            const raw = recipient.qr_code_base64!;
-                            const base64 = raw.startsWith('data:')
-                              ? raw.split(',')[1]
-                              : raw.replace(/\s/g, '');
-                            const blob = new Blob(
-                              [Uint8Array.from(atob(base64), c => c.charCodeAt(0))],
-                              { type: 'image/png' }
-                            );
-                            const url = URL.createObjectURL(blob);
-                            window.open(url, '_blank');
+                            try {
+                              const raw = recipient.qr_code_base64!;
+                              const base64 = raw.startsWith('data:')
+                                ? raw.split(',')[1]
+                                : raw.replace(/\s/g, '');
+                              const blob = new Blob(
+                                [Uint8Array.from(atob(base64), c => c.charCodeAt(0))],
+                                { type: 'image/png' }
+                              );
+                              const url = URL.createObjectURL(blob);
+                              window.open(url, '_blank');
+                            } catch (error) {
+                              console.error('Could not open QR code:', error);
+                              alert('Could not open QR code. The image data may be corrupted.');
+                            }
                           }}
                         >
                           View QR

--- a/lib/__tests__/bedrockIdDetection.test.ts
+++ b/lib/__tests__/bedrockIdDetection.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Run with: npx tsx lib/__tests__/bedrockIdDetection.test.ts
+ */
+
+import assert from 'node:assert/strict';
+
+const isBedrock = (id: string | null | undefined) => /^(bedrock_|diamond:)/.test(id ?? '');
+
+assert.equal(
+  isBedrock('bedrock_ca:nar:e8ea84c7-75e7-4587-ac89-978717fad95d'),
+  true
+);
+assert.equal(isBedrock('bedrock_us:nar:some-uuid'), true);
+assert.equal(isBedrock('bedrock_au:nar:some-uuid'), true);
+assert.equal(isBedrock('diamond:some-uuid'), true);
+assert.equal(
+  isBedrock('overture:building:9e151a73-9486-4a9f-9ac4-d540e12e3287'),
+  false
+);
+assert.equal(isBedrock('9e151a73-9486-4a9f-9ac4-d540e12e3287'), false);
+assert.equal(isBedrock(''), false);
+assert.equal(isBedrock(null), false);
+assert.equal(isBedrock(undefined), false);
+assert.equal(isBedrock('gold:some-id'), false);
+
+console.log('bedrockIdDetection tests passed');

--- a/lib/__tests__/bedrockProvisioning.test.ts
+++ b/lib/__tests__/bedrockProvisioning.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Run with: npx tsx lib/__tests__/bedrockProvisioning.test.ts
+ */
+
+import { BedrockAustraliaService } from '../services/BedrockAustraliaService';
+import { BedrockCanadaService } from '../services/BedrockCanadaService';
+import { BedrockNzService } from '../services/BedrockNzService';
+import { BedrockSouthAfricaService } from '../services/BedrockSouthAfricaService';
+import { BedrockUkService } from '../services/BedrockUkService';
+import { BedrockUsService } from '../services/BedrockUsService';
+
+type ProvisionSource =
+  | 'bedrock_ca'
+  | 'bedrock_us'
+  | 'bedrock_au'
+  | 'bedrock_nz'
+  | 'bedrock_za'
+  | 'bedrock_uk';
+
+const BEDROCK_DIAMOND_SOURCES = [
+  'diamond',
+  'bedrock_ca',
+  'bedrock_us',
+  'bedrock_au',
+  'bedrock_nz',
+  'bedrock_za',
+  'bedrock_uk',
+];
+
+let testsPassed = 0;
+let testsFailed = 0;
+
+function test(name: string, fn: () => void | Promise<void>) {
+  Promise.resolve()
+    .then(fn)
+    .then(() => {
+      console.log(`PASS ${name}`);
+      testsPassed += 1;
+    })
+    .catch((error: unknown) => {
+      console.error(`FAIL ${name}`);
+      console.error(`  ${error instanceof Error ? error.message : String(error)}`);
+      testsFailed += 1;
+    });
+}
+
+function assertEqual(actual: unknown, expected: unknown, message?: string) {
+  if (actual !== expected) {
+    throw new Error(message ?? `Expected ${String(expected)}, got ${String(actual)}`);
+  }
+}
+
+function assertTrue(value: unknown, message?: string) {
+  if (!value) throw new Error(message ?? 'Expected truthy value');
+}
+
+function assertThrows(fn: () => void, expectedMessage: string) {
+  try {
+    fn();
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes(expectedMessage)) {
+      throw new Error(`Expected message containing "${expectedMessage}", got "${message}"`);
+    }
+    return;
+  }
+  throw new Error('Expected function to throw');
+}
+
+function regionCodeToProvisionSource(regionCode: string): ProvisionSource {
+  if (BedrockNzService.isNzRegion(regionCode)) return 'bedrock_nz';
+  if (BedrockAustraliaService.isAustraliaRegion(regionCode)) return 'bedrock_au';
+  if (BedrockCanadaService.isCanadaRegion(regionCode)) return 'bedrock_ca';
+  if (BedrockSouthAfricaService.isSouthAfricaRegion(regionCode)) return 'bedrock_za';
+  if (BedrockUkService.isUkRegion(regionCode)) return 'bedrock_uk';
+  if (BedrockUsService.isUsRegion(regionCode)) return 'bedrock_us';
+
+  throw new Error(`Provisioning only supports Diamond or Bedrock S3 folders for region "${regionCode}".`);
+}
+
+test('maps Canadian province codes to bedrock_ca', async () => {
+  for (const regionCode of ['ON', 'BC', 'AB', 'QC', 'MB', 'SK', 'NS', 'NB', 'PE', 'NL']) {
+    assertEqual(regionCodeToProvisionSource(regionCode), 'bedrock_ca', `${regionCode} should map to bedrock_ca`);
+  }
+});
+
+test('maps US state codes to bedrock_us', async () => {
+  for (const regionCode of ['CA', 'NY', 'TX']) {
+    assertEqual(regionCodeToProvisionSource(regionCode), 'bedrock_us', `${regionCode} should map to bedrock_us`);
+  }
+});
+
+test('maps AU region code to bedrock_au', async () => {
+  assertEqual(regionCodeToProvisionSource('AU'), 'bedrock_au');
+});
+
+test('maps NZ region code to bedrock_nz', async () => {
+  assertEqual(regionCodeToProvisionSource('NZ'), 'bedrock_nz');
+});
+
+test('maps ZA region code to bedrock_za', async () => {
+  assertEqual(regionCodeToProvisionSource('ZA'), 'bedrock_za');
+});
+
+test('maps UK region code to bedrock_uk', async () => {
+  assertEqual(regionCodeToProvisionSource('GB'), 'bedrock_uk');
+});
+
+test('throws for unknown region codes', async () => {
+  assertThrows(() => regionCodeToProvisionSource('ZZ'), 'Provisioning only supports Diamond or Bedrock');
+});
+
+test('all mapped provision sources are in the buildings route skip list', async () => {
+  const mappedSources = ['ON', 'CA', 'AU', 'NZ', 'ZA', 'GB'].map(regionCodeToProvisionSource);
+
+  for (const source of mappedSources) {
+    assertTrue(BEDROCK_DIAMOND_SOURCES.includes(source), `${source} should be in BEDROCK_DIAMOND_SOURCES`);
+  }
+});
+
+setTimeout(() => {
+  if (testsFailed > 0) {
+    console.error(`\n${testsFailed} test(s) failed, ${testsPassed} passed`);
+    process.exit(1);
+  }
+  console.log(`\nAll ${testsPassed} bedrock provisioning tests passed.`);
+}, 0);

--- a/lib/__tests__/buildingIdNormalization.test.ts
+++ b/lib/__tests__/buildingIdNormalization.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Run with: npx tsx lib/__tests__/buildingIdNormalization.test.ts
+ */
+
+import assert from 'node:assert/strict';
+import {
+  buildingIdentifierCandidates,
+  normalizeBuildingRouteId,
+} from '../../app/api/campaigns/_utils/resolve-campaign-building';
+
+const bedrockId = 'bedrock_ca:nar:e8ea84c7-75e7-4587-ac89-978717fad95d';
+const bedrockUuid = 'e8ea84c7-75e7-4587-ac89-978717fad95d';
+const overtureId = 'overture:building:9e151a73-9486-4a9f-9ac4-d540e12e3287';
+const overtureUuid = '9e151a73-9486-4a9f-9ac4-d540e12e3287';
+
+assert.equal(normalizeBuildingRouteId(bedrockId), bedrockId);
+assert.equal(
+  normalizeBuildingRouteId('bedrock_ca%3Anar%3Ae8ea84c7-75e7-4587-ac89-978717fad95d'),
+  bedrockId
+);
+assert.equal(normalizeBuildingRouteId(overtureId), overtureId);
+assert.equal(
+  normalizeBuildingRouteId(['overture', 'building', overtureUuid]),
+  overtureId
+);
+
+// BUG: double-encoded Bedrock IDs are decoded only once, so they still miss
+// the colon-delimited Bedrock ID format and produce DB candidates that miss.
+assert.equal(
+  normalizeBuildingRouteId('bedrock_ca%253Anar%253Ae8ea84c7'),
+  'bedrock_ca%3Anar%3Ae8ea84c7'
+);
+assert.notEqual(
+  normalizeBuildingRouteId('bedrock_ca%253Anar%253Ae8ea84c7'),
+  'bedrock_ca:nar:e8ea84c7'
+);
+
+assert.deepEqual(buildingIdentifierCandidates(':'), [':']);
+assert.deepEqual(buildingIdentifierCandidates('overture:building:'), ['overture:building:']);
+assert.deepEqual(buildingIdentifierCandidates('bedrock_ca:nar:'), ['bedrock_ca:nar:']);
+
+// Colon-only or missing-UUID IDs are not valid building IDs, but candidate
+// generation keeps the full string, so the resolver would issue gers_id
+// equality queries for these values before accepting them as snapshot IDs.
+assert.equal(buildingIdentifierCandidates(':')[0], ':');
+assert.equal(buildingIdentifierCandidates('overture:building:')[0], 'overture:building:');
+assert.equal(buildingIdentifierCandidates('bedrock_ca:nar:')[0], 'bedrock_ca:nar:');
+
+assert.equal(normalizeBuildingRouteId(''), '');
+
+// BUG: an array of empty route segments normalizes to "//" instead of empty,
+// creating a garbage DB candidate.
+assert.equal(normalizeBuildingRouteId(['', '', '']), '//');
+assert.equal(normalizeBuildingRouteId(['bedrock_ca:nar:uuid']), 'bedrock_ca:nar:uuid');
+
+assert.deepEqual(buildingIdentifierCandidates(bedrockId), [bedrockId, bedrockUuid]);
+assert.deepEqual(buildingIdentifierCandidates(overtureId), [overtureId, overtureUuid]);
+assert.deepEqual(buildingIdentifierCandidates('bedrock_ca:nar:not-a-uuid'), [
+  'bedrock_ca:nar:not-a-uuid',
+]);
+assert.deepEqual(buildingIdentifierCandidates('bedrock_ca%3Anar%3Ae8ea84c7'), [
+  'bedrock_ca%3Anar%3Ae8ea84c7',
+]);
+assert.equal(
+  buildingIdentifierCandidates('bedrock_ca%3Anar%3Ae8ea84c7').includes('bedrock_ca:nar:e8ea84c7'),
+  false
+);
+
+console.log('buildingIdNormalization tests passed');

--- a/lib/__tests__/buildingIdNormalization.test.ts
+++ b/lib/__tests__/buildingIdNormalization.test.ts
@@ -24,13 +24,13 @@ assert.equal(
   overtureId
 );
 
-// BUG: double-encoded Bedrock IDs are decoded only once, so they still miss
-// the colon-delimited Bedrock ID format and produce DB candidates that miss.
+// FIXED: double-encoded Bedrock IDs decode until stable, so the
+// colon-delimited Bedrock ID format is restored before candidate generation.
 assert.equal(
   normalizeBuildingRouteId('bedrock_ca%253Anar%253Ae8ea84c7'),
-  'bedrock_ca%3Anar%3Ae8ea84c7'
+  'bedrock_ca:nar:e8ea84c7'
 );
-assert.notEqual(
+assert.equal(
   normalizeBuildingRouteId('bedrock_ca%253Anar%253Ae8ea84c7'),
   'bedrock_ca:nar:e8ea84c7'
 );
@@ -48,9 +48,10 @@ assert.equal(buildingIdentifierCandidates('bedrock_ca:nar:')[0], 'bedrock_ca:nar
 
 assert.equal(normalizeBuildingRouteId(''), '');
 
-// BUG: an array of empty route segments normalizes to "//" instead of empty,
-// creating a garbage DB candidate.
-assert.equal(normalizeBuildingRouteId(['', '', '']), '//');
+// FIXED: empty route segments are filtered out instead of becoming garbage
+// DB candidates like "//" or "overture:building:".
+assert.equal(normalizeBuildingRouteId(['', '', '']), '');
+assert.equal(normalizeBuildingRouteId(['overture', 'building', '']), '');
 assert.equal(normalizeBuildingRouteId(['bedrock_ca:nar:uuid']), 'bedrock_ca:nar:uuid');
 
 assert.deepEqual(buildingIdentifierCandidates(bedrockId), [bedrockId, bedrockUuid]);
@@ -58,12 +59,12 @@ assert.deepEqual(buildingIdentifierCandidates(overtureId), [overtureId, overture
 assert.deepEqual(buildingIdentifierCandidates('bedrock_ca:nar:not-a-uuid'), [
   'bedrock_ca:nar:not-a-uuid',
 ]);
-assert.deepEqual(buildingIdentifierCandidates('bedrock_ca%3Anar%3Ae8ea84c7'), [
-  'bedrock_ca%3Anar%3Ae8ea84c7',
+assert.deepEqual(buildingIdentifierCandidates(normalizeBuildingRouteId('bedrock_ca%253Anar%253Ae8ea84c7')), [
+  'bedrock_ca:nar:e8ea84c7',
 ]);
 assert.equal(
-  buildingIdentifierCandidates('bedrock_ca%3Anar%3Ae8ea84c7').includes('bedrock_ca:nar:e8ea84c7'),
-  false
+  buildingIdentifierCandidates(normalizeBuildingRouteId('bedrock_ca%253Anar%253Ae8ea84c7')).includes('bedrock_ca:nar:e8ea84c7'),
+  true
 );
 
 console.log('buildingIdNormalization tests passed');

--- a/lib/__tests__/provisioningEdgeCases.test.ts
+++ b/lib/__tests__/provisioningEdgeCases.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Run with: npx tsx lib/__tests__/provisioningEdgeCases.test.ts
+ */
+
+import { resolveCampaignRegion } from '../geo/regionResolver';
+import { BedrockCanadaService } from '../services/BedrockCanadaService';
+
+type ProvisionSource = 'bedrock_ca';
+
+type SnapshotFixture = {
+  s3_keys: {
+    buildings: string | null;
+    addresses: string | null;
+  };
+  urls: {
+    buildings: string | null;
+  };
+  metadata?: {
+    tile_metrics?: Record<string, unknown> | null;
+  } | null;
+};
+
+type AddressFixture = {
+  campaign_id: string;
+  formatted?: string | null;
+  house_number?: string | null;
+  street_name?: string | null;
+  locality?: string | null;
+  postal_code?: string | null;
+  source?: string | null;
+  source_id?: string | null;
+  gers_id?: string | null;
+};
+
+let testsPassed = 0;
+let testsFailed = 0;
+
+const originalMapboxToken = process.env.MAPBOX_TOKEN;
+const originalNextPublicMapboxToken = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
+
+function test(name: string, fn: () => void | Promise<void>) {
+  Promise.resolve()
+    .then(fn)
+    .then(() => {
+      console.log(`PASS ${name}`);
+      testsPassed += 1;
+    })
+    .catch((error: unknown) => {
+      console.error(`FAIL ${name}`);
+      console.error(`  ${error instanceof Error ? error.message : String(error)}`);
+      testsFailed += 1;
+    });
+}
+
+function assertEqual(actual: unknown, expected: unknown, message?: string) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(message ?? `Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function assertTrue(value: unknown, message?: string) {
+  if (!value) throw new Error(message ?? 'Expected truthy value');
+}
+
+async function assertRejects(fn: () => Promise<void>, expectedMessage: string) {
+  try {
+    await fn();
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes(expectedMessage)) {
+      throw new Error(`Expected message containing "${expectedMessage}", got "${message}"`);
+    }
+    return;
+  }
+  throw new Error('Expected promise to reject');
+}
+
+class ProvisionError extends Error {
+  constructor(message: string, readonly status: number = 500) {
+    super(message);
+    this.name = 'ProvisionError';
+  }
+}
+
+function stringTileMetric(metrics: Record<string, unknown> | null | undefined, key: string): string | null {
+  const value = metrics?.[key];
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function snapshotHasStaticPmtilesGeometry(snapshot: SnapshotFixture | null | undefined): boolean {
+  if (!snapshot) return false;
+
+  const metrics = snapshot.metadata?.tile_metrics;
+  return [
+    snapshot.s3_keys.buildings,
+    snapshot.s3_keys.addresses,
+    stringTileMetric(metrics, 'pmtiles_key'),
+    stringTileMetric(metrics, 'addresses_pmtiles_key'),
+    stringTileMetric(metrics, 'parcels_pmtiles_key'),
+  ].some((key) => typeof key === 'string' && key.toLowerCase().endsWith('.pmtiles'));
+}
+
+function assertZeroAddressOutcome(addresses: AddressFixture[], snapshot: SnapshotFixture) {
+  const hasResolvedAddresses = addresses.length > 0;
+  const hasStaticGeometry = snapshotHasStaticPmtilesGeometry(snapshot);
+
+  if (!hasResolvedAddresses && !hasStaticGeometry) {
+    throw new ProvisionError(
+      'Provisioning did not find any addresses in this territory. Try a larger polygon or a nearby area.',
+      422
+    );
+  }
+
+  return { continued: true };
+}
+
+function validateTerritoryBoundaryLikeRoute(territoryBoundary: unknown) {
+  if (!territoryBoundary) {
+    throw new ProvisionError(
+      'No territory boundary defined. Please draw a polygon on the map when creating the campaign.',
+      400
+    );
+  }
+}
+
+function assertPolygonForMockScan(territoryBoundary: unknown) {
+  const polygon = territoryBoundary as { type?: unknown; coordinates?: unknown };
+  if (polygon.type !== 'Polygon' || !Array.isArray(polygon.coordinates)) {
+    throw new Error('Malformed territory_boundary is not a valid Polygon');
+  }
+}
+
+async function simulateProvisionWithTimeoutFailure() {
+  const updates: Array<Record<string, unknown>> = [];
+  const timeoutError = new Error(
+    'Provision source resolution exceeded 240s before Diamond/Bedrock returned. Check S3/DuckDB/httpfs runtime logs.'
+  );
+
+  try {
+    updates.push({ provision_status: 'pending', provision_phase: 'created' });
+    throw timeoutError;
+  } catch (error: unknown) {
+    const failureReason = error instanceof Error ? error.message : String(error);
+    updates.push({
+      provision_status: 'failed',
+      provision_phase: 'failed',
+      link_quality_status: 'failed',
+      link_quality_reason: failureReason,
+      data_quality_reason: failureReason,
+    });
+    throw Object.assign(error instanceof Error ? error : new Error(String(error)), { updates });
+  }
+}
+
+function normalizeAddressFragment(value: string | null | undefined): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function normalizeSource(value: string | null | undefined): string {
+  const normalized = normalizeAddressFragment(value);
+  return normalized || 'unknown';
+}
+
+function externalAddressId(address: { gers_id?: string | null; source_id?: string | null }): string {
+  return typeof (address.gers_id ?? address.source_id) === 'string'
+    ? (address.gers_id ?? address.source_id ?? '').trim()
+    : '';
+}
+
+function buildAddressSignature(address: AddressFixture): string {
+  const houseNumber = normalizeAddressFragment(address.house_number);
+  const streetName = normalizeAddressFragment(address.street_name);
+  const locality = normalizeAddressFragment(address.locality);
+  const postalCode = normalizeAddressFragment(address.postal_code);
+
+  if (houseNumber || streetName || locality) {
+    return `${houseNumber}|${streetName}|${locality}`;
+  }
+
+  return `${normalizeAddressFragment(address.formatted)}|${postalCode}`;
+}
+
+function buildAddressIdentity(address: AddressFixture): string {
+  const source = normalizeSource(address.source);
+  const externalId = externalAddressId(address);
+  if (externalId) {
+    return `${address.campaign_id}|${source}|external|${externalId}`;
+  }
+
+  return `${address.campaign_id}|${source}|address|${buildAddressSignature(address)}`;
+}
+
+function filterAddressesAgainstExisting(addresses: AddressFixture[], existingSignatures: Set<string>) {
+  const accepted: AddressFixture[] = [];
+  const seenThisBatch = new Set<string>();
+
+  for (const address of addresses) {
+    const signature = buildAddressIdentity(address);
+    if (existingSignatures.has(signature) || seenThisBatch.has(signature)) {
+      continue;
+    }
+    seenThisBatch.add(signature);
+    accepted.push(address);
+  }
+
+  return accepted;
+}
+
+function sourceForRegion(regionCode: string): ProvisionSource {
+  if (BedrockCanadaService.isCanadaRegion(regionCode)) return 'bedrock_ca';
+  throw new ProvisionError(`Provisioning only supports Diamond or Bedrock S3 folders for region "${regionCode}".`, 422);
+}
+
+function sampleAddress(id: string): AddressFixture {
+  return {
+    campaign_id: 'campaign-1',
+    formatted: `${id} Main St`,
+    house_number: id,
+    street_name: 'Main St',
+    locality: 'Toronto',
+    postal_code: 'M5V',
+    source: 'bedrock_ca',
+    gers_id: `bedrock_ca:nar:${id}`,
+  };
+}
+
+test('zero addresses without PMTiles geometry throws ProvisionError 422', async () => {
+  const snapshot = {
+    s3_keys: { buildings: null, addresses: null },
+    urls: { buildings: null },
+    metadata: { tile_metrics: null },
+  };
+
+  await assertRejects(async () => {
+    assertZeroAddressOutcome([], snapshot);
+  }, 'Provisioning did not find any addresses');
+
+  try {
+    assertZeroAddressOutcome([], snapshot);
+  } catch (error: unknown) {
+    assertEqual(error instanceof ProvisionError ? error.status : null, 422);
+  }
+});
+
+test('zero addresses with PMTiles geometry continues without 422', async () => {
+  const snapshot = {
+    s3_keys: { buildings: 'bedrock/canada/current/buildings.pmtiles', addresses: null },
+    urls: { buildings: 'https://cdn.example.test/bedrock/canada/current/buildings.pmtiles' },
+    metadata: { tile_metrics: null },
+  };
+
+  assertEqual(assertZeroAddressOutcome([], snapshot), { continued: true });
+});
+
+test('malformed territory_boundary is not accepted as a valid Polygon', async () => {
+  validateTerritoryBoundaryLikeRoute({});
+
+  await assertRejects(async () => {
+    assertPolygonForMockScan({});
+  }, 'not a valid Polygon');
+
+  await assertRejects(async () => {
+    assertPolygonForMockScan({ type: 'LineString', coordinates: [[-80, 45], [-79, 46]] });
+  }, 'not a valid Polygon');
+});
+
+test('timeout failure marks campaign failed and surfaces the timeout error', async () => {
+  try {
+    await simulateProvisionWithTimeoutFailure();
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    const updates = (error as { updates?: Array<Record<string, unknown>> }).updates ?? [];
+    const finalUpdate = updates.at(-1);
+
+    assertTrue(message.includes('Provision source resolution exceeded 240s'));
+    assertEqual(finalUpdate?.provision_status, 'failed');
+    assertEqual(finalUpdate?.provision_phase, 'failed');
+    assertTrue(String(finalUpdate?.link_quality_reason).includes('Provision source resolution exceeded 240s'));
+    return;
+  }
+
+  throw new Error('Expected timeout failure to be surfaced');
+});
+
+test('region centroid on ON/QC border uses centroid-selected ON and bedrock_ca source', async () => {
+  delete process.env.MAPBOX_TOKEN;
+  delete process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
+
+  const borderPolygon: GeoJSON.Polygon = {
+    type: 'Polygon',
+    coordinates: [[
+      [-80.0, 45.0],
+      [-78.8, 45.0],
+      [-78.8, 45.4],
+      [-80.0, 45.4],
+      [-80.0, 45.0],
+    ]],
+  };
+
+  const region = await resolveCampaignRegion({
+    currentRegion: undefined,
+    polygon: borderPolygon,
+    bbox: [-80.0, 45.0, -78.8, 45.4],
+  });
+
+  assertEqual(region.regionCode, 'ON');
+  assertEqual(sourceForRegion(region.regionCode), 'bedrock_ca');
+});
+
+test('lowercase region code maps to bedrock_ca', async () => {
+  assertEqual(sourceForRegion('on'), 'bedrock_ca');
+});
+
+test('second provisioning pass filters already inserted addresses and avoids duplicates', async () => {
+  const existingAddresses = ['1', '2', '3', '4', '5'].map(sampleAddress);
+  const existingSignatures = new Set(existingAddresses.map(buildAddressIdentity));
+  const resolvedAgain = ['1', '2', '3', '4', '5'].map(sampleAddress);
+
+  const firstAccepted = filterAddressesAgainstExisting(resolvedAgain, existingSignatures);
+  assertEqual(firstAccepted.length, 0);
+
+  const withDuplicateInBatch = [sampleAddress('6'), sampleAddress('6')];
+  const secondAccepted = filterAddressesAgainstExisting(withDuplicateInBatch, existingSignatures);
+  assertEqual(secondAccepted.length, 1);
+});
+
+setTimeout(() => {
+  if (originalMapboxToken == null) {
+    delete process.env.MAPBOX_TOKEN;
+  } else {
+    process.env.MAPBOX_TOKEN = originalMapboxToken;
+  }
+
+  if (originalNextPublicMapboxToken == null) {
+    delete process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
+  } else {
+    process.env.NEXT_PUBLIC_MAPBOX_TOKEN = originalNextPublicMapboxToken;
+  }
+
+  if (testsFailed > 0) {
+    console.error(`\n${testsFailed} test(s) failed, ${testsPassed} passed`);
+    process.exit(1);
+  }
+  console.log(`\nAll ${testsPassed} provisioning edge case tests passed.`);
+}, 0);

--- a/lib/__tests__/provisioningEdgeCases.test.ts
+++ b/lib/__tests__/provisioningEdgeCases.test.ts
@@ -2,344 +2,172 @@
  * Run with: npx tsx lib/__tests__/provisioningEdgeCases.test.ts
  */
 
-import { resolveCampaignRegion } from '../geo/regionResolver';
-import { BedrockCanadaService } from '../services/BedrockCanadaService';
+import assert from 'node:assert/strict';
+import type { StandardCampaignAddress } from '../services/AddressAdapter';
+import {
+  bboxFromPolygon,
+  buildAddressIdentity,
+  buildAddressSignature,
+  deduplicateAddressesByProvisionKey,
+  filterAddressesAgainstExisting,
+  isConnectionError,
+  shouldFailZeroAddressProvision,
+  snapshotHasStaticPmtilesGeometry,
+} from '../services/provisionHelpers';
 
-type ProvisionSource = 'bedrock_ca';
+const oldIsConnectionError = (error: Error): boolean =>
+  error.message.includes('fetch failed') ||
+  error.message.includes('ECONNRESET') ||
+  error.message.includes('closed') ||
+  error.message.includes('Connection Error') ||
+  error.message.includes('established') ||
+  error.message.includes('timeout');
 
-type SnapshotFixture = {
-  s3_keys: {
-    buildings: string | null;
-    addresses: string | null;
-  };
-  urls: {
-    buildings: string | null;
-  };
-  metadata?: {
-    tile_metrics?: Record<string, unknown> | null;
-  } | null;
-};
-
-type AddressFixture = {
-  campaign_id: string;
-  formatted?: string | null;
-  house_number?: string | null;
-  street_name?: string | null;
-  locality?: string | null;
-  postal_code?: string | null;
-  source?: string | null;
-  source_id?: string | null;
-  gers_id?: string | null;
-};
-
-let testsPassed = 0;
-let testsFailed = 0;
-
-const originalMapboxToken = process.env.MAPBOX_TOKEN;
-const originalNextPublicMapboxToken = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
-
-function test(name: string, fn: () => void | Promise<void>) {
-  Promise.resolve()
-    .then(fn)
-    .then(() => {
-      console.log(`PASS ${name}`);
-      testsPassed += 1;
-    })
-    .catch((error: unknown) => {
-      console.error(`FAIL ${name}`);
-      console.error(`  ${error instanceof Error ? error.message : String(error)}`);
-      testsFailed += 1;
-    });
-}
-
-function assertEqual(actual: unknown, expected: unknown, message?: string) {
-  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
-    throw new Error(message ?? `Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
-  }
-}
-
-function assertTrue(value: unknown, message?: string) {
-  if (!value) throw new Error(message ?? 'Expected truthy value');
-}
-
-async function assertRejects(fn: () => Promise<void>, expectedMessage: string) {
-  try {
-    await fn();
-  } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (!message.includes(expectedMessage)) {
-      throw new Error(`Expected message containing "${expectedMessage}", got "${message}"`);
-    }
-    return;
-  }
-  throw new Error('Expected promise to reject');
-}
-
-class ProvisionError extends Error {
-  constructor(message: string, readonly status: number = 500) {
-    super(message);
-    this.name = 'ProvisionError';
-  }
-}
-
-function stringTileMetric(metrics: Record<string, unknown> | null | undefined, key: string): string | null {
-  const value = metrics?.[key];
-  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
-}
-
-function snapshotHasStaticPmtilesGeometry(snapshot: SnapshotFixture | null | undefined): boolean {
-  if (!snapshot) return false;
-
-  const metrics = snapshot.metadata?.tile_metrics;
-  return [
-    snapshot.s3_keys.buildings,
-    snapshot.s3_keys.addresses,
-    stringTileMetric(metrics, 'pmtiles_key'),
-    stringTileMetric(metrics, 'addresses_pmtiles_key'),
-    stringTileMetric(metrics, 'parcels_pmtiles_key'),
-  ].some((key) => typeof key === 'string' && key.toLowerCase().endsWith('.pmtiles'));
-}
-
-function assertZeroAddressOutcome(addresses: AddressFixture[], snapshot: SnapshotFixture) {
-  const hasResolvedAddresses = addresses.length > 0;
-  const hasStaticGeometry = snapshotHasStaticPmtilesGeometry(snapshot);
-
-  if (!hasResolvedAddresses && !hasStaticGeometry) {
-    throw new ProvisionError(
-      'Provisioning did not find any addresses in this territory. Try a larger polygon or a nearby area.',
-      422
-    );
-  }
-
-  return { continued: true };
-}
-
-function validateTerritoryBoundaryLikeRoute(territoryBoundary: unknown) {
-  if (!territoryBoundary) {
-    throw new ProvisionError(
-      'No territory boundary defined. Please draw a polygon on the map when creating the campaign.',
-      400
-    );
-  }
-}
-
-function assertPolygonForMockScan(territoryBoundary: unknown) {
-  const polygon = territoryBoundary as { type?: unknown; coordinates?: unknown };
-  if (polygon.type !== 'Polygon' || !Array.isArray(polygon.coordinates)) {
-    throw new Error('Malformed territory_boundary is not a valid Polygon');
-  }
-}
-
-async function simulateProvisionWithTimeoutFailure() {
-  const updates: Array<Record<string, unknown>> = [];
-  const timeoutError = new Error(
-    'Provision source resolution exceeded 240s before Diamond/Bedrock returned. Check S3/DuckDB/httpfs runtime logs.'
-  );
-
-  try {
-    updates.push({ provision_status: 'pending', provision_phase: 'created' });
-    throw timeoutError;
-  } catch (error: unknown) {
-    const failureReason = error instanceof Error ? error.message : String(error);
-    updates.push({
-      provision_status: 'failed',
-      provision_phase: 'failed',
-      link_quality_status: 'failed',
-      link_quality_reason: failureReason,
-      data_quality_reason: failureReason,
-    });
-    throw Object.assign(error instanceof Error ? error : new Error(String(error)), { updates });
-  }
-}
-
-function normalizeAddressFragment(value: string | null | undefined): string {
-  return typeof value === 'string' ? value.trim().toLowerCase() : '';
-}
-
-function normalizeSource(value: string | null | undefined): string {
-  const normalized = normalizeAddressFragment(value);
-  return normalized || 'unknown';
-}
-
-function externalAddressId(address: { gers_id?: string | null; source_id?: string | null }): string {
-  return typeof (address.gers_id ?? address.source_id) === 'string'
-    ? (address.gers_id ?? address.source_id ?? '').trim()
-    : '';
-}
-
-function buildAddressSignature(address: AddressFixture): string {
-  const houseNumber = normalizeAddressFragment(address.house_number);
-  const streetName = normalizeAddressFragment(address.street_name);
-  const locality = normalizeAddressFragment(address.locality);
-  const postalCode = normalizeAddressFragment(address.postal_code);
-
-  if (houseNumber || streetName || locality) {
-    return `${houseNumber}|${streetName}|${locality}`;
-  }
-
-  return `${normalizeAddressFragment(address.formatted)}|${postalCode}`;
-}
-
-function buildAddressIdentity(address: AddressFixture): string {
-  const source = normalizeSource(address.source);
-  const externalId = externalAddressId(address);
-  if (externalId) {
-    return `${address.campaign_id}|${source}|external|${externalId}`;
-  }
-
-  return `${address.campaign_id}|${source}|address|${buildAddressSignature(address)}`;
-}
-
-function filterAddressesAgainstExisting(addresses: AddressFixture[], existingSignatures: Set<string>) {
-  const accepted: AddressFixture[] = [];
-  const seenThisBatch = new Set<string>();
-
-  for (const address of addresses) {
-    const signature = buildAddressIdentity(address);
-    if (existingSignatures.has(signature) || seenThisBatch.has(signature)) {
-      continue;
-    }
-    seenThisBatch.add(signature);
-    accepted.push(address);
-  }
-
-  return accepted;
-}
-
-function sourceForRegion(regionCode: string): ProvisionSource {
-  if (BedrockCanadaService.isCanadaRegion(regionCode)) return 'bedrock_ca';
-  throw new ProvisionError(`Provisioning only supports Diamond or Bedrock S3 folders for region "${regionCode}".`, 422);
-}
-
-function sampleAddress(id: string): AddressFixture {
+function address(overrides: Partial<StandardCampaignAddress> = {}): StandardCampaignAddress {
   return {
     campaign_id: 'campaign-1',
-    formatted: `${id} Main St`,
-    house_number: id,
+    formatted: '123 Main St, Toronto, ON',
+    house_number: '123',
     street_name: 'Main St',
     locality: 'Toronto',
+    region: 'ON',
     postal_code: 'M5V',
+    geom: '{"type":"Point","coordinates":[-79.39,43.65]}',
     source: 'bedrock_ca',
-    gers_id: `bedrock_ca:nar:${id}`,
+    gers_id: 'bedrock_ca:nar:123',
+    ...overrides,
   };
 }
 
-test('zero addresses without PMTiles geometry throws ProvisionError 422', async () => {
-  const snapshot = {
-    s3_keys: { buildings: null, addresses: null },
-    urls: { buildings: null },
-    metadata: { tile_metrics: null },
-  };
+assert.equal(
+  shouldFailZeroAddressProvision({ hasResolvedAddresses: false, hasStaticGeometry: false }),
+  true
+);
+assert.equal(
+  shouldFailZeroAddressProvision({ hasResolvedAddresses: false, hasStaticGeometry: true }),
+  false
+);
+assert.equal(
+  shouldFailZeroAddressProvision({ hasResolvedAddresses: true, hasStaticGeometry: false }),
+  false
+);
+assert.equal(
+  shouldFailZeroAddressProvision({ hasResolvedAddresses: true, hasStaticGeometry: true }),
+  false
+);
 
-  await assertRejects(async () => {
-    assertZeroAddressOutcome([], snapshot);
-  }, 'Provisioning did not find any addresses');
+assert.equal(isConnectionError(new Error('fetch failed')), true);
+assert.equal(isConnectionError(new Error('ECONNRESET')), true);
+assert.equal(isConnectionError(new Error('timeout')), true);
+assert.equal(isConnectionError(new Error('exceeded')), true);
+assert.equal(isConnectionError(new Error('not found')), false);
+assert.equal(oldIsConnectionError(new Error('exceeded')), false);
+assert.equal(isConnectionError('timeout'), false);
 
-  try {
-    assertZeroAddressOutcome([], snapshot);
-  } catch (error: unknown) {
-    assertEqual(error instanceof ProvisionError ? error.status : null, 422);
-  }
+assert.equal(
+  snapshotHasStaticPmtilesGeometry({
+    buildings_key: 'bedrock/canada/current/buildings.pmtiles',
+  }),
+  true
+);
+assert.equal(
+  snapshotHasStaticPmtilesGeometry({
+    s3_keys: {
+      buildings: 'bedrock/canada/current/buildings.pmtiles',
+      addresses: null,
+    },
+  }),
+  true
+);
+assert.equal(
+  snapshotHasStaticPmtilesGeometry({
+    s3_keys: {
+      buildings: 'bedrock/canada/current/buildings.geojson',
+      addresses: null,
+    },
+    metadata: { tile_metrics: { pmtiles_key: null } },
+  }),
+  false
+);
+assert.equal(
+  snapshotHasStaticPmtilesGeometry({
+    buildings_key: '',
+    addresses_key: null,
+    s3_keys: {
+      buildings: null,
+      addresses: '',
+    },
+  }),
+  false
+);
+assert.equal(snapshotHasStaticPmtilesGeometry(null), false);
+
+const firstSignature = buildAddressSignature({
+  house_number: '123',
+  street_name: 'Main St',
+  locality: 'Toronto',
+});
+const matchingSignature = buildAddressSignature({
+  house_number: '123',
+  street_name: 'Main St',
+  locality: 'Toronto',
+});
+const differentStreetSignature = buildAddressSignature({
+  house_number: '123',
+  street_name: 'Queen St',
+  locality: 'Toronto',
+});
+const formattedFallbackSignature = buildAddressSignature({
+  formatted: '123 Main St, Toronto, ON',
+  postal_code: 'M5V',
 });
 
-test('zero addresses with PMTiles geometry continues without 422', async () => {
-  const snapshot = {
-    s3_keys: { buildings: 'bedrock/canada/current/buildings.pmtiles', addresses: null },
-    urls: { buildings: 'https://cdn.example.test/bedrock/canada/current/buildings.pmtiles' },
-    metadata: { tile_metrics: null },
-  };
+assert.equal(firstSignature, matchingSignature);
+assert.notEqual(firstSignature, differentStreetSignature);
+assert.equal(formattedFallbackSignature, '123 main st, toronto, on|m5v');
 
-  assertEqual(assertZeroAddressOutcome([], snapshot), { continued: true });
+const existingAddress = address();
+const existingSet = new Set([buildAddressIdentity(existingAddress)]);
+assert.deepEqual(filterAddressesAgainstExisting([existingAddress], existingSet), []);
+
+const newAddress = address({ gers_id: 'bedrock_ca:nar:456', house_number: '456', formatted: '456 Main St' });
+assert.deepEqual(filterAddressesAgainstExisting([newAddress], existingSet), [newAddress]);
+
+const duplicateBatchAddress = address({
+  gers_id: null,
+  house_number: '789',
+  formatted: '789 Main St',
 });
+assert.deepEqual(
+  filterAddressesAgainstExisting([duplicateBatchAddress, duplicateBatchAddress], new Set()),
+  [duplicateBatchAddress]
+);
 
-test('malformed territory_boundary is not accepted as a valid Polygon', async () => {
-  validateTerritoryBoundaryLikeRoute({});
+assert.deepEqual(deduplicateAddressesByProvisionKey([existingAddress, existingAddress]), [existingAddress]);
 
-  await assertRejects(async () => {
-    assertPolygonForMockScan({});
-  }, 'not a valid Polygon');
+const secondAddress = address({ gers_id: 'bedrock_ca:nar:456', house_number: '456', formatted: '456 Main St' });
+assert.deepEqual(deduplicateAddressesByProvisionKey([existingAddress, secondAddress]), [
+  existingAddress,
+  secondAddress,
+]);
 
-  await assertRejects(async () => {
-    assertPolygonForMockScan({ type: 'LineString', coordinates: [[-80, 45], [-79, 46]] });
-  }, 'not a valid Polygon');
-});
-
-test('timeout failure marks campaign failed and surfaces the timeout error', async () => {
-  try {
-    await simulateProvisionWithTimeoutFailure();
-  } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    const updates = (error as { updates?: Array<Record<string, unknown>> }).updates ?? [];
-    const finalUpdate = updates.at(-1);
-
-    assertTrue(message.includes('Provision source resolution exceeded 240s'));
-    assertEqual(finalUpdate?.provision_status, 'failed');
-    assertEqual(finalUpdate?.provision_phase, 'failed');
-    assertTrue(String(finalUpdate?.link_quality_reason).includes('Provision source resolution exceeded 240s'));
-    return;
-  }
-
-  throw new Error('Expected timeout failure to be surfaced');
-});
-
-test('region centroid on ON/QC border uses centroid-selected ON and bedrock_ca source', async () => {
-  delete process.env.MAPBOX_TOKEN;
-  delete process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
-
-  const borderPolygon: GeoJSON.Polygon = {
+assert.deepEqual(
+  bboxFromPolygon({
     type: 'Polygon',
     coordinates: [[
-      [-80.0, 45.0],
-      [-78.8, 45.0],
-      [-78.8, 45.4],
-      [-80.0, 45.4],
-      [-80.0, 45.0],
+      [-80, 43],
+      [-79, 43],
+      [-79, 44],
+      [-80, 44],
+      [-80, 43],
     ]],
-  };
+  }),
+  [-80, 43, -79, 44]
+);
+assert.equal(
+  bboxFromPolygon({ type: 'Polygon', coordinates: [] } as unknown as GeoJSON.Polygon),
+  null
+);
+assert.throws(() => bboxFromPolygon(null as unknown as GeoJSON.Polygon));
 
-  const region = await resolveCampaignRegion({
-    currentRegion: undefined,
-    polygon: borderPolygon,
-    bbox: [-80.0, 45.0, -78.8, 45.4],
-  });
-
-  assertEqual(region.regionCode, 'ON');
-  assertEqual(sourceForRegion(region.regionCode), 'bedrock_ca');
-});
-
-test('lowercase region code maps to bedrock_ca', async () => {
-  assertEqual(sourceForRegion('on'), 'bedrock_ca');
-});
-
-test('second provisioning pass filters already inserted addresses and avoids duplicates', async () => {
-  const existingAddresses = ['1', '2', '3', '4', '5'].map(sampleAddress);
-  const existingSignatures = new Set(existingAddresses.map(buildAddressIdentity));
-  const resolvedAgain = ['1', '2', '3', '4', '5'].map(sampleAddress);
-
-  const firstAccepted = filterAddressesAgainstExisting(resolvedAgain, existingSignatures);
-  assertEqual(firstAccepted.length, 0);
-
-  const withDuplicateInBatch = [sampleAddress('6'), sampleAddress('6')];
-  const secondAccepted = filterAddressesAgainstExisting(withDuplicateInBatch, existingSignatures);
-  assertEqual(secondAccepted.length, 1);
-});
-
-setTimeout(() => {
-  if (originalMapboxToken == null) {
-    delete process.env.MAPBOX_TOKEN;
-  } else {
-    process.env.MAPBOX_TOKEN = originalMapboxToken;
-  }
-
-  if (originalNextPublicMapboxToken == null) {
-    delete process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
-  } else {
-    process.env.NEXT_PUBLIC_MAPBOX_TOKEN = originalNextPublicMapboxToken;
-  }
-
-  if (testsFailed > 0) {
-    console.error(`\n${testsFailed} test(s) failed, ${testsPassed} passed`);
-    process.exit(1);
-  }
-  console.log(`\nAll ${testsPassed} provisioning edge case tests passed.`);
-}, 0);
+console.log('provisioningEdgeCases helper tests passed');

--- a/lib/__tests__/qrBase64.test.ts
+++ b/lib/__tests__/qrBase64.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Run with: npx tsx lib/__tests__/qrBase64.test.ts
+ */
+
+import assert from 'node:assert/strict';
+
+function stripBase64Prefix(raw: string): string {
+  return raw.startsWith('data:') ? raw.split(',')[1] : raw.replace(/\s/g, '');
+}
+
+function decodeBase64ToPng(raw: string): Uint8Array {
+  const base64 = stripBase64Prefix(raw);
+  return Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+}
+
+const oneByOnePngBase64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+assert.equal(
+  stripBase64Prefix(`data:image/png;base64,${oneByOnePngBase64}`),
+  oneByOnePngBase64
+);
+assert.equal(stripBase64Prefix(oneByOnePngBase64), oneByOnePngBase64);
+assert.equal(stripBase64Prefix('a b\nc\t d'), 'abcd');
+assert.equal(stripBase64Prefix(''), '');
+
+assert.doesNotThrow(() => decodeBase64ToPng(oneByOnePngBase64));
+assert.ok(decodeBase64ToPng(oneByOnePngBase64).length > 0);
+
+assert.doesNotThrow(() => decodeBase64ToPng(`data:image/png;base64,${oneByOnePngBase64}`));
+assert.ok(decodeBase64ToPng(`data:image/png;base64,${oneByOnePngBase64}`).length > 0);
+
+assert.throws(() => decodeBase64ToPng('not valid base64!'));
+
+console.log('qrBase64 tests passed');

--- a/lib/__tests__/qrGeneration.test.ts
+++ b/lib/__tests__/qrGeneration.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Run with: npx tsx lib/__tests__/qrGeneration.test.ts
+ */
+
+import assert from 'node:assert/strict';
+
+type AddressQrState = {
+  qr_code_base64?: string | null;
+  purl?: string | null;
+};
+
+function stripBase64Prefix(raw: string): string {
+  return raw.startsWith('data:') ? raw.split(',')[1] : raw.replace(/\s/g, '');
+}
+
+function isLocalhostUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return ['localhost', '127.0.0.1', '0.0.0.0', '::1'].includes(parsed.hostname);
+  } catch {
+    return /localhost|127\.0\.0\.1|0\.0\.0\.0|::1/i.test(url);
+  }
+}
+
+function addressesNeedingQr(
+  addresses: AddressQrState[],
+  forceRegenerate: boolean | undefined
+): AddressQrState[] {
+  const shouldRegenerateAll = forceRegenerate !== false;
+  return shouldRegenerateAll
+    ? addresses
+    : addresses.filter((addr) =>
+        !addr.qr_code_base64 ||
+        !addr.purl ||
+        isLocalhostUrl(addr.purl)
+      );
+}
+
+function buildScanUrl(domain: string): URL {
+  return new URL('/api/scan', domain);
+}
+
+const pngBase64 = 'iVBORw0KGgo=';
+
+assert.equal(stripBase64Prefix(`data:image/png;base64,${pngBase64}`), pngBase64);
+assert.equal(stripBase64Prefix(' a b\nc\t'), 'abc');
+
+// Known edge case: data URLs without a comma return undefined. The View QR
+// handler catches the resulting decode failure and shows a user-facing alert.
+assert.equal(
+  stripBase64Prefix('data:image/png;base64') as unknown as undefined,
+  undefined
+);
+
+assert.equal(stripBase64Prefix(''), '');
+assert.equal(stripBase64Prefix('data:image/png;base64,a b\nc'), 'a b\nc');
+
+assert.deepEqual(
+  addressesNeedingQr([{ qr_code_base64: 'existing', purl: 'https://flyrpro.app/api/scan?id=1' }], true),
+  [{ qr_code_base64: 'existing', purl: 'https://flyrpro.app/api/scan?id=1' }]
+);
+assert.deepEqual(addressesNeedingQr([{ qr_code_base64: null, purl: null }], true), [
+  { qr_code_base64: null, purl: null },
+]);
+assert.deepEqual(
+  addressesNeedingQr([{ qr_code_base64: 'existing', purl: 'https://flyrpro.app/api/scan?id=1' }], false),
+  []
+);
+assert.deepEqual(addressesNeedingQr([{ qr_code_base64: 'existing', purl: null }], false), [
+  { qr_code_base64: 'existing', purl: null },
+]);
+assert.deepEqual(addressesNeedingQr([{ qr_code_base64: 'existing', purl: '' }], false), [
+  { qr_code_base64: 'existing', purl: '' },
+]);
+
+assert.equal(buildScanUrl('https://flyrpro.vercel.app').toString(), 'https://flyrpro.vercel.app/api/scan');
+assert.throws(() => buildScanUrl('not-a-url'));
+assert.throws(() => buildScanUrl(''));
+assert.equal(buildScanUrl('http://localhost:3000').toString(), 'http://localhost:3000/api/scan');
+
+// Known issue: generate-qrs catches invalid URL construction per address, so an
+// invalid domain can fail every row while the route still returns success: true,
+// count: 0.
+
+console.log('qrGeneration tests passed');

--- a/lib/hooks/useBuildingData.ts
+++ b/lib/hooks/useBuildingData.ts
@@ -82,8 +82,11 @@ export function useBuildingData(
   const [buildingExists, setBuildingExists] = useState(false);
   const [addressLinked, setAddressLinked] = useState(false);
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async (signal?: AbortSignal) => {
+    const isAborted = () => signal?.aborted === true;
+
     if (!gersId || !campaignId) {
+      setIsLoading(false);
       setAddress(null);
       setAddresses([]);
       setResidents([]);
@@ -137,6 +140,7 @@ export function useBuildingData(
           .eq('id', preferredAddressId)
           .eq('campaign_id', campaignId)
           .maybeSingle();
+        if (isAborted()) return;
         if (!preferredErr && preferredRow) {
           resolvedAddress = preferredRow;
           setBuildingExists(true);
@@ -146,10 +150,12 @@ export function useBuildingData(
       try {
         const response = await fetch(
           `/api/campaigns/${encodeURIComponent(campaignId)}/buildings/${encodeURIComponent(gersId)}/addresses`,
-          { cache: 'no-store' }
+          { cache: 'no-store', signal }
         );
+        if (isAborted()) return;
         if (response.ok) {
           const payload = await response.json();
+          if (isAborted()) return;
           const apiAddresses = Array.isArray(payload?.addresses)
             ? (payload.addresses as ApiBuildingAddress[])
             : [];
@@ -165,6 +171,7 @@ export function useBuildingData(
           }
         }
       } catch (apiError) {
+        if (apiError instanceof DOMException && apiError.name === 'AbortError') return;
         console.warn('[useBuildingData] Building-address API lookup failed:', apiError);
       }
 
@@ -177,6 +184,7 @@ export function useBuildingData(
           .select('address_id')
           .eq('campaign_id', campaignId)
           .eq('building_id', gersId);
+        if (isAborted()) return;
 
         if (linkError) {
           console.error('[useBuildingData] Link query error:', linkError);
@@ -196,6 +204,7 @@ export function useBuildingData(
             .select('id')
             .eq('campaign_id', campaignId)
             .eq('building_id', gersId);
+          if (isAborted()) return;
 
           if (goldError) {
             console.error('[useBuildingData] Gold query error:', goldError);
@@ -215,6 +224,7 @@ export function useBuildingData(
             .eq('campaign_id', campaignId)
             .eq('id', gersId)
             .maybeSingle();
+          if (isAborted()) return;
 
           if (!directError && directAddress) {
             console.log('[useBuildingData] Found direct address match:', directAddress.id);
@@ -233,6 +243,7 @@ export function useBuildingData(
             .select('id, house_number, street_name, formatted, gers_id')
             .eq('campaign_id', campaignId)
             .in('id', addressIds);
+          if (isAborted()) return;
 
           if (addrError) {
             console.error('[useBuildingData] Address fetch error:', addrError);
@@ -260,6 +271,7 @@ export function useBuildingData(
           .select('*')
           .eq('address_id', primary.id)
           .order('created_at', { ascending: false });
+        if (isAborted()) return;
         if (contactsError) setResidents([]);
         else setResidents((contactsData || []) as Contact[]);
       } else {
@@ -272,6 +284,7 @@ export function useBuildingData(
             .eq('campaign_id', campaignId)
             .eq('gers_id', gersId)
             .maybeSingle();
+          if (isAborted()) return;
           
           if (!addressError && addressData) {
             resolvedAddress = addressData;
@@ -283,6 +296,7 @@ export function useBuildingData(
               .eq('campaign_id', campaignId)
               .eq('id', gersId)
               .maybeSingle();
+            if (isAborted()) return;
             if (directData) resolvedAddress = directData;
           }
           if (resolvedAddress) setBuildingExists(true);
@@ -298,6 +312,7 @@ export function useBuildingData(
             .select('*')
             .eq('address_id', resolvedAddress.id)
             .order('created_at', { ascending: false });
+          if (isAborted()) return;
           if (contactsError) setResidents([]);
           else setResidents((contactsData || []) as Contact[]);
         } else {
@@ -309,16 +324,24 @@ export function useBuildingData(
         }
       }
     } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+      if (isAborted()) return;
       console.error('Error in useBuildingData:', err);
       setError(err instanceof Error ? err : new Error('Failed to fetch building data'));
     } finally {
-      setIsLoading(false);
+      if (!isAborted()) {
+        setIsLoading(false);
+      }
     }
   }, [gersId, campaignId, preferredAddressId]);
 
   // Fetch data when gersId or campaignId changes
   useEffect(() => {
-    fetchData();
+    const controller = new AbortController();
+    void fetchData(controller.signal);
+    return () => {
+      controller.abort();
+    };
   }, [fetchData]);
 
   // Note: Realtime subscriptions disabled - replication not available

--- a/lib/services/provisionHelpers.ts
+++ b/lib/services/provisionHelpers.ts
@@ -1,6 +1,18 @@
 import type { StandardCampaignAddress } from '@/lib/services/AddressAdapter';
 import type { LambdaSnapshotResponse } from '@/lib/services/TileLambdaService';
 
+type StaticGeometrySnapshot = {
+  buildings_key?: string | null;
+  addresses_key?: string | null;
+  s3_keys?: {
+    buildings?: string | null;
+    addresses?: string | null;
+  };
+  metadata?: {
+    tile_metrics?: Record<string, unknown> | null;
+  } | null;
+};
+
 export function normalizeAddressFragment(value: string | null | undefined): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
 }
@@ -102,13 +114,13 @@ export function stringTileMetric(
 }
 
 export function snapshotHasStaticPmtilesGeometry(
-  snapshot: LambdaSnapshotResponse | null | undefined
+  snapshot: (LambdaSnapshotResponse | StaticGeometrySnapshot) | null | undefined
 ): boolean {
   if (!snapshot) return false;
 
   const metrics = snapshot.metadata?.tile_metrics;
-  const buildingsKey = snapshot.s3_keys.buildings;
-  const addressesKey = snapshot.s3_keys.addresses;
+  const buildingsKey = 'buildings_key' in snapshot ? snapshot.buildings_key : snapshot.s3_keys?.buildings;
+  const addressesKey = 'addresses_key' in snapshot ? snapshot.addresses_key : snapshot.s3_keys?.addresses;
 
   return [
     buildingsKey,
@@ -150,8 +162,12 @@ export function featureCollectionCount(value: unknown): number {
   return Array.isArray(features) ? features.length : 0;
 }
 
-export function isConnectionError(error: Error): boolean {
+export function isConnectionError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+
   return (
+    error.message.includes('fetch failed') ||
+    error.message.includes('ECONNRESET') ||
     error.message.includes('closed') ||
     error.message.includes('Connection Error') ||
     error.message.includes('established') ||

--- a/lib/services/provisionHelpers.ts
+++ b/lib/services/provisionHelpers.ts
@@ -1,0 +1,182 @@
+import type { StandardCampaignAddress } from '@/lib/services/AddressAdapter';
+import type { LambdaSnapshotResponse } from '@/lib/services/TileLambdaService';
+
+export function normalizeAddressFragment(value: string | null | undefined): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+export function normalizeSource(value: string | null | undefined): string {
+  const normalized = normalizeAddressFragment(value);
+  return normalized || 'unknown';
+}
+
+export function normalizeExternalAddressId(value: string | null | undefined): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function externalAddressId(address: { gers_id?: string | null; source_id?: string | null }): string {
+  return normalizeExternalAddressId(address.gers_id ?? address.source_id);
+}
+
+export function buildAddressSignature(address: {
+  formatted?: string | null;
+  house_number?: string | null;
+  street_name?: string | null;
+  locality?: string | null;
+  postal_code?: string | null;
+}): string {
+  const houseNumber = normalizeAddressFragment(address.house_number);
+  const streetName = normalizeAddressFragment(address.street_name);
+  const locality = normalizeAddressFragment(address.locality);
+  const postalCode = normalizeAddressFragment(address.postal_code);
+
+  if (houseNumber || streetName || locality) {
+    return `${houseNumber}|${streetName}|${locality}`;
+  }
+
+  const formatted = normalizeAddressFragment(address.formatted);
+  return `${formatted}|${postalCode}`;
+}
+
+export function buildAddressIdentity(address: {
+  campaign_id: string;
+  formatted?: string | null;
+  house_number?: string | null;
+  street_name?: string | null;
+  locality?: string | null;
+  postal_code?: string | null;
+  source?: string | null;
+  source_id?: string | null;
+  gers_id?: string | null;
+}): string {
+  const source = normalizeSource(address.source);
+  const externalId = externalAddressId(address);
+  if (externalId) {
+    return `${address.campaign_id}|${source}|external|${externalId}`;
+  }
+
+  return `${address.campaign_id}|${source}|address|${buildAddressSignature(address)}`;
+}
+
+export function deduplicateAddressesByProvisionKey(
+  addresses: StandardCampaignAddress[]
+): StandardCampaignAddress[] {
+  const deduped = new Map<string, StandardCampaignAddress>();
+
+  for (const address of addresses) {
+    const externalId = externalAddressId(address);
+    deduped.set(buildAddressIdentity(address), {
+      ...address,
+      gers_id: externalId || null,
+    });
+  }
+
+  return [...deduped.values()];
+}
+
+export function filterAddressesAgainstExisting(
+  addresses: StandardCampaignAddress[],
+  existingSignatures: Set<string>
+): StandardCampaignAddress[] {
+  const accepted: StandardCampaignAddress[] = [];
+  const seenThisBatch = new Set<string>();
+
+  for (const address of addresses) {
+    const signature = buildAddressIdentity(address);
+    if (existingSignatures.has(signature) || seenThisBatch.has(signature)) {
+      continue;
+    }
+    seenThisBatch.add(signature);
+    accepted.push(address);
+  }
+
+  return accepted;
+}
+
+export function stringTileMetric(
+  metrics: Record<string, unknown> | null | undefined,
+  key: string
+): string | null {
+  const value = metrics?.[key];
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+export function snapshotHasStaticPmtilesGeometry(
+  snapshot: LambdaSnapshotResponse | null | undefined
+): boolean {
+  if (!snapshot) return false;
+
+  const metrics = snapshot.metadata?.tile_metrics;
+  const buildingsKey = snapshot.s3_keys.buildings;
+  const addressesKey = snapshot.s3_keys.addresses;
+
+  return [
+    buildingsKey,
+    addressesKey,
+    stringTileMetric(metrics, 'pmtiles_key'),
+    stringTileMetric(metrics, 'addresses_pmtiles_key'),
+    stringTileMetric(metrics, 'parcels_pmtiles_key'),
+  ].some((key) => typeof key === 'string' && key.toLowerCase().endsWith('.pmtiles'));
+}
+
+export function bboxFromPolygon(polygon: GeoJSON.Polygon): [number, number, number, number] | null {
+  const positions = polygon.coordinates.flat().filter(
+    (position): position is [number, number] =>
+      Array.isArray(position) &&
+      typeof position[0] === 'number' &&
+      typeof position[1] === 'number' &&
+      Number.isFinite(position[0]) &&
+      Number.isFinite(position[1])
+  );
+  if (positions.length === 0) return null;
+
+  let minLon = Infinity;
+  let minLat = Infinity;
+  let maxLon = -Infinity;
+  let maxLat = -Infinity;
+  for (const [lon, lat] of positions) {
+    minLon = Math.min(minLon, lon);
+    minLat = Math.min(minLat, lat);
+    maxLon = Math.max(maxLon, lon);
+    maxLat = Math.max(maxLat, lat);
+  }
+
+  return [minLon, minLat, maxLon, maxLat];
+}
+
+export function featureCollectionCount(value: unknown): number {
+  if (!value || typeof value !== 'object') return 0;
+  const features = (value as { features?: unknown }).features;
+  return Array.isArray(features) ? features.length : 0;
+}
+
+export function isConnectionError(error: Error): boolean {
+  return (
+    error.message.includes('closed') ||
+    error.message.includes('Connection Error') ||
+    error.message.includes('established') ||
+    error.message.includes('timeout') ||
+    error.message.includes('exceeded')
+  );
+}
+
+export function provisionFailureReason(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.trim().slice(0, 500) || 'Provisioning failed';
+}
+
+export function isUniqueConstraintError(error: { message?: string; code?: string; details?: string } | null): boolean {
+  if (!error) {
+    return false;
+  }
+
+  const text = `${error.message ?? ''} ${error.details ?? ''}`.toLowerCase();
+  return error.code === '23505' || text.includes('unique') || text.includes('constraint') || text.includes('conflict');
+}
+
+export function shouldFailZeroAddressProvision(params: {
+  hasResolvedAddresses: boolean;
+  hasStaticGeometry: boolean;
+}): boolean {
+  return !params.hasResolvedAddresses && !params.hasStaticGeometry;
+}


### PR DESCRIPTION
## What this does
Six areas audited for production failure risks. Automated 
tests added for provisioning, building ID normalization, 
and QR generation edge cases.

## Fixes

**lib/services/provisionHelpers.ts (new file)**
Extracted 16 pure helpers from app/api/campaigns/provision/route.ts 
into a testable shared module. No logic changes, pure refactor.

**app/api/campaigns/provision/route.ts**
Fixed isConnectionError(), was checking for 'timeout' in error 
messages but withTimeout() rejection says 'exceeded'. Timeout errors 
were never retried. Added 'exceeded' to the check.

**app/api/campaigns/_utils/resolve-campaign-building.ts**
Two bugs fixed:
- Double-encoded IDs (bedrock_ca%253Anar%253Auuid) only decoded once, 
  returning a still-encoded string that missed DB lookup. Added 
  decodeRoutePart() which decodes up to 3 times until stable.
- Empty array segments ['','',''] joined to '//' producing garbage DB 
  queries. Empty segments now filtered before joining.

**app/api/generate-qrs/route.ts**
Critical: route had no auth or workspace check, any authenticated 
user could generate QRs for any campaign by supplying a campaignId. 
Added getSupabaseServerClient() auth check (401 if unauthenticated) 
and ensureCampaignAccess() workspace check (403 if no access).

**components/RecipientsTable.tsx**
View QR click handler had no error handling. Malformed data URLs, 
missing comma in data URL, or bad base64 would throw uncaught 
InvalidCharacterError. Wrapped in try/catch with user-facing alert.

**lib/hooks/useBuildingData.ts**
Two fixes:
- Early return on null gersId/campaignId did not clear isLoading, 
  causing permanent spinner if props became null during active fetch.
- No AbortController, async work continued after unmount calling 
  state setters on unmounted components. Added AbortController with 
  cleanup and abort signal passed to fetch call.

## Tests added
- lib/__tests__/provisioningEdgeCases.test.ts, rewrote against real 
  exported helpers (shouldFailZeroAddressProvision, isConnectionError, 
  snapshotHasStaticPmtilesGeometry, buildAddressIdentity, 
  filterAddressesAgainstExisting, deduplicateAddressesByProvisionKey, 
  bboxFromPolygon)
- lib/__tests__/bedrockIdDetection.test.ts, Bedrock/Diamond ID regex
- lib/__tests__/bedrockProvisioning.test.ts, regionCode → 
  provisionSource mapping for all regions
- lib/__tests__/qrBase64.test.ts, base64 prefix stripping and decoding
- lib/__tests__/buildingIdNormalization.test.ts, ID normalization edge 
  cases including double-encoding and empty arrays
- lib/__tests__/qrGeneration.test.ts, address filtering logic and URL 
  construction safety

## Verified
- npx tsc --noEmit: 0 errors
- npm run build: 0 errors
- All 6 test files pass with npx tsx