### PR TITLE
feat: error boundaries, loading skeletons, and user-facing error states

### DIFF
--- a/app/(main)/campaigns/[campaignId]/loading.tsx
+++ b/app/(main)/campaigns/[campaignId]/loading.tsx
@@ -1,0 +1,25 @@
+export default function CampaignDetailLoading() {
+  return (
+    <div className="flex min-h-full flex-col bg-background text-foreground">
+      <div className="border-b border-border bg-background px-4 py-4 sm:px-6">
+        <div className="h-6 w-48 animate-pulse rounded bg-muted" />
+        <div className="mt-3 h-4 w-72 max-w-full animate-pulse rounded bg-muted/70" />
+      </div>
+      <div className="border-b border-border bg-background px-4 py-3 sm:px-6">
+        <div className="flex gap-2 overflow-hidden">
+          <div className="h-8 w-24 animate-pulse rounded-md bg-muted" />
+          <div className="h-8 w-24 animate-pulse rounded-md bg-muted/80" />
+          <div className="h-8 w-24 animate-pulse rounded-md bg-muted/70" />
+        </div>
+      </div>
+      <div className="grid flex-1 gap-4 p-4 sm:p-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <div className="min-h-[360px] animate-pulse rounded-lg border border-border bg-muted/40" />
+        <div className="space-y-4">
+          <div className="h-28 animate-pulse rounded-lg border border-border bg-muted/40" />
+          <div className="h-40 animate-pulse rounded-lg border border-border bg-muted/30" />
+          <div className="h-24 animate-pulse rounded-lg border border-border bg-muted/30" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/campaigns/[campaignId]/page.tsx
+++ b/app/(main)/campaigns/[campaignId]/page.tsx
@@ -503,6 +503,7 @@ export default function CampaignDetailPage() {
   });
   const [contacts, setContacts] = useState<CampaignContact[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [showPaywall, setShowPaywall] = useState(false);
   const [showMissingQRModal, setShowMissingQRModal] = useState(false);
@@ -537,6 +538,7 @@ export default function CampaignDetailPage() {
   const canAddCampaignNote = Boolean(campaignNoteDraft.trim() || campaignNotePdf);
 
   const loadData = useCallback(async () => {
+    setLoadError(false);
     try {
       const supabase = createClient();
       const [campaignData, addressesData, contactsData, scanEventsRes, roadMetaRes] = await Promise.all([
@@ -569,6 +571,7 @@ export default function CampaignDetailPage() {
       }
     } catch (error) {
       console.error('Error loading campaign:', error);
+      setLoadError(true);
     } finally {
       setLoading(false);
     }
@@ -866,6 +869,23 @@ export default function CampaignDetailPage() {
     return (
       <div className="flex items-center justify-center min-h-[320px]">
         <LoadingScreen variant="inline" />
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[320px] px-6 text-center">
+        <h2 className="text-lg font-semibold text-foreground mb-2">Failed to load campaign</h2>
+        <p className="text-sm text-muted-foreground mb-4">
+          There was a problem loading this campaign. Please try again.
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <Button onClick={loadData}>Try again</Button>
+          <Button asChild variant="outline">
+            <Link href="/campaigns">Back to campaigns</Link>
+          </Button>
+        </div>
       </div>
     );
   }

--- a/app/(main)/campaigns/[campaignId]/page.tsx
+++ b/app/(main)/campaigns/[campaignId]/page.tsx
@@ -571,7 +571,11 @@ export default function CampaignDetailPage() {
       }
     } catch (error) {
       console.error('Error loading campaign:', error);
-      setLoadError(true);
+      if ((error as { code?: string } | null)?.code === 'PGRST116') {
+        setCampaign(null);
+      } else {
+        setLoadError(true);
+      }
     } finally {
       setLoading(false);
     }

--- a/app/(main)/campaigns/error.tsx
+++ b/app/(main)/campaigns/error.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { AlertTriangle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+function campaignLabelFromPath(pathname: string | null): string | null {
+  if (!pathname?.startsWith('/campaigns/')) return null;
+  const segment = pathname.slice('/campaigns/'.length).split('/')[0];
+  if (!segment || segment === 'create') return null;
+  return segment;
+}
+
+export default function CampaignsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const campaignLabel = campaignLabelFromPath(usePathname());
+
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-full items-center justify-center bg-background px-4 py-10 text-foreground">
+      <section className="w-full max-w-lg rounded-lg border border-border bg-card p-6 text-center shadow-sm sm:p-8">
+        <div className="mx-auto mb-5 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10 text-destructive">
+          <AlertTriangle className="h-6 w-6" aria-hidden="true" />
+        </div>
+        <div className="mb-6 space-y-3">
+          <p className="text-sm font-semibold uppercase tracking-wide text-destructive">Campaign error</p>
+          <h1 className="text-2xl font-semibold tracking-tight">This campaign could not be loaded.</h1>
+          {campaignLabel ? (
+            <p className="text-sm text-muted-foreground">Campaign: {campaignLabel}</p>
+          ) : null}
+          <p className="text-sm leading-6 text-muted-foreground">
+            Please try again. If the problem persists, return to the campaign list.
+          </p>
+        </div>
+        <div className="flex flex-col justify-center gap-3 sm:flex-row">
+          <Button onClick={reset}>Try again</Button>
+          <Button variant="outline" asChild>
+            <Link href="/campaigns">All campaigns</Link>
+          </Button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/(main)/error.tsx
+++ b/app/(main)/error.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import {
+  Activity,
+  AlertTriangle,
+  CalendarCheck,
+  Gauge,
+  Home,
+  Settings,
+  Target,
+  Trophy,
+  Users,
+} from 'lucide-react';
+import { FarmIcon } from '@/components/icons/FarmIcon';
+import { Button } from '@/components/ui/button';
+
+const navItems = [
+  { href: '/home', label: 'Home', icon: Home },
+  { href: '/campaigns', label: 'Campaign', icon: Target },
+  { href: '/farms', label: 'Farm', icon: FarmIcon },
+  { href: '/activity', label: 'Activity', icon: Activity },
+  { href: '/leads', label: 'Leads', icon: Users },
+  { href: '/appointments', label: 'Appointments', icon: CalendarCheck },
+  { href: '/leaderboard', label: 'Leaderboard', icon: Trophy },
+  { href: '/stats', label: 'Performance', icon: Gauge },
+  { href: '/settings', label: 'Settings', icon: Settings },
+];
+
+export default function MainError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-screen bg-background text-foreground">
+      <aside className="hidden w-16 shrink-0 border-r border-border bg-sidebar px-2 py-3 md:flex md:flex-col md:items-center md:gap-3">
+        <Link
+          href="/home"
+          aria-label="FLYR dashboard"
+          className="mb-2 flex h-9 w-9 items-center justify-center rounded-md bg-red-500 text-sm font-bold text-white"
+        >
+          F
+        </Link>
+        {navItems.map((item) => {
+          const Icon = item.icon;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              aria-label={item.label}
+              title={item.label}
+              className="flex h-9 w-9 items-center justify-center rounded-md text-sidebar-foreground/80 transition-colors hover:bg-muted/50 hover:text-sidebar-foreground"
+            >
+              <Icon className="h-4 w-4" aria-hidden="true" />
+            </Link>
+          );
+        })}
+      </aside>
+      <main className="flex min-h-screen flex-1 items-center justify-center px-4 py-10">
+        <section className="w-full max-w-lg rounded-lg border border-border bg-card p-6 text-center shadow-sm sm:p-8">
+          <div className="mx-auto mb-5 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10 text-destructive">
+            <AlertTriangle className="h-6 w-6" aria-hidden="true" />
+          </div>
+          <div className="mb-6 space-y-3">
+            <p className="text-sm font-semibold uppercase tracking-wide text-destructive">FLYR</p>
+            <h1 className="text-2xl font-semibold tracking-tight">Something went wrong</h1>
+            <p className="text-sm leading-6 text-muted-foreground">
+              An unexpected error occurred. Please try again or return to your dashboard.
+            </p>
+          </div>
+          <div className="flex flex-col justify-center gap-3 sm:flex-row">
+            <Button onClick={reset}>Try again</Button>
+            <Button variant="outline" asChild>
+              <Link href="/">Go to dashboard</Link>
+            </Button>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/app/farms/[id]/loading.tsx
+++ b/app/farms/[id]/loading.tsx
@@ -1,0 +1,26 @@
+export default function FarmDetailLoading() {
+  return (
+    <div className="flex min-h-full flex-col bg-background text-foreground">
+      <div className="border-b border-border bg-background px-4 py-4 sm:px-6">
+        <div className="h-6 w-44 animate-pulse rounded bg-muted" />
+        <div className="mt-3 h-4 w-64 max-w-full animate-pulse rounded bg-muted/70" />
+      </div>
+      <div className="border-b border-border bg-background px-4 py-3 sm:px-6">
+        <div className="flex gap-2 overflow-hidden">
+          <div className="h-8 w-20 animate-pulse rounded-md bg-muted" />
+          <div className="h-8 w-20 animate-pulse rounded-md bg-muted/80" />
+          <div className="h-8 w-20 animate-pulse rounded-md bg-muted/70" />
+          <div className="h-8 w-20 animate-pulse rounded-md bg-muted/60" />
+        </div>
+      </div>
+      <div className="grid flex-1 gap-4 p-4 sm:p-6 lg:grid-cols-[minmax(0,1fr)_340px]">
+        <div className="min-h-[360px] animate-pulse rounded-lg border border-border bg-muted/40" />
+        <div className="space-y-4">
+          <div className="h-32 animate-pulse rounded-lg border border-border bg-muted/40" />
+          <div className="h-36 animate-pulse rounded-lg border border-border bg-muted/30" />
+          <div className="h-28 animate-pulse rounded-lg border border-border bg-muted/30" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/farms/[id]/page.tsx
+++ b/app/farms/[id]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import {
   BarChart3,
@@ -242,6 +243,7 @@ export default function FarmPage() {
   const [financeEntries, setFinanceEntries] = useState<FinanceEntry[]>([]);
   const [touchOutcomes, setTouchOutcomes] = useState<FarmTouchAddress[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState('overview');
   const [overviewScope, setOverviewScope] = useState<DashboardScope>('current_cycle');
@@ -305,6 +307,7 @@ export default function FarmPage() {
   const currentFlyerUrl = linkedCampaign?.flyer_url ?? legacyCampaignText.flyerUrl ?? null;
 
   const loadData = useCallback(async (resolvedUserId?: string | null) => {
+    setLoadError(false);
     try {
       const [farmData, addressData, touchData, leadData, contactData, financeData, outcomeData, linkedCampaignResponse] = await Promise.all([
         FarmService.fetchFarm(farmId),
@@ -362,6 +365,7 @@ export default function FarmPage() {
       }
     } catch (error) {
       console.error('Error loading farm:', error);
+      setLoadError(true);
     } finally {
       setLoading(false);
     }
@@ -1439,6 +1443,23 @@ export default function FarmPage() {
 
   if (loading) {
     return <div className="h-full flex items-center justify-center text-muted-foreground">Loading farm...</div>;
+  }
+
+  if (loadError) {
+    return (
+      <div className="flex h-full min-h-[320px] flex-col items-center justify-center px-6 text-center">
+        <h2 className="mb-2 text-lg font-semibold text-foreground">Failed to load farm</h2>
+        <p className="mb-4 text-sm text-muted-foreground">
+          There was a problem loading this farm. Please try again.
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <Button onClick={() => void loadData(userId)}>Try again</Button>
+          <Button asChild variant="outline">
+            <Link href="/farms">Back to farms</Link>
+          </Button>
+        </div>
+      </div>
+    );
   }
 
   if (!farm) {

--- a/app/farms/error.tsx
+++ b/app/farms/error.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { AlertTriangle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+function farmLabelFromPath(pathname: string | null): string | null {
+  if (!pathname?.startsWith('/farms/')) return null;
+  const segment = pathname.slice('/farms/'.length).split('/')[0];
+  if (!segment || segment === 'create') return null;
+  return segment;
+}
+
+export default function FarmsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const farmLabel = farmLabelFromPath(usePathname());
+
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-full items-center justify-center bg-background px-4 py-10 text-foreground">
+      <section className="w-full max-w-lg rounded-lg border border-border bg-card p-6 text-center shadow-sm sm:p-8">
+        <div className="mx-auto mb-5 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10 text-destructive">
+          <AlertTriangle className="h-6 w-6" aria-hidden="true" />
+        </div>
+        <div className="mb-6 space-y-3">
+          <p className="text-sm font-semibold uppercase tracking-wide text-destructive">Farm error</p>
+          <h1 className="text-2xl font-semibold tracking-tight">This farm could not be loaded.</h1>
+          {farmLabel ? <p className="text-sm text-muted-foreground">Farm: {farmLabel}</p> : null}
+          <p className="text-sm leading-6 text-muted-foreground">
+            Please try again. If the problem persists, return to the farm list.
+          </p>
+        </div>
+        <div className="flex flex-col justify-center gap-3 sm:flex-row">
+          <Button onClick={reset}>Try again</Button>
+          <Button variant="outline" asChild>
+            <Link href="/farms">All farms</Link>
+          </Button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { AlertTriangle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  const refreshPage = () => {
+    reset();
+    window.location.reload();
+  };
+
+  return (
+    <html lang="en">
+      <body>
+        <main className="flex min-h-screen items-center justify-center bg-background px-4 py-10 text-foreground">
+          <section className="w-full max-w-lg rounded-lg border border-border bg-card p-6 text-center shadow-sm sm:p-8">
+            <div className="mx-auto mb-5 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10 text-destructive">
+              <AlertTriangle className="h-6 w-6" aria-hidden="true" />
+            </div>
+            <div className="mb-6 space-y-3">
+              <p className="text-sm font-semibold uppercase tracking-wide text-destructive">FLYR</p>
+              <h1 className="text-2xl font-semibold tracking-tight">Something went wrong</h1>
+              <p className="text-sm leading-6 text-muted-foreground">
+                An unexpected error occurred. Please refresh the page or contact support if the
+                problem persists.
+              </p>
+            </div>
+            <div className="flex flex-col justify-center gap-3 sm:flex-row">
+              <Button onClick={refreshPage}>Refresh page</Button>
+              <Button variant="outline" asChild>
+                <Link href="/">Go to dashboard</Link>
+              </Button>
+            </div>
+          </section>
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/components/campaigns/CampaignListSidebar.tsx
+++ b/components/campaigns/CampaignListSidebar.tsx
@@ -46,6 +46,7 @@ export function CampaignListSidebar({
   const copy = getIndustryCopy(currentWorkspace?.industry);
   const [campaigns, setCampaigns] = useState<CampaignV2[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [statusTab, setStatusTab] = useState<StatusTab>('active');
@@ -65,27 +66,31 @@ export function CampaignListSidebar({
     [pathname, router]
   );
 
-  useEffect(() => {
-    const run = async () => {
-      try {
-        const supabase = await getClientAsync();
-        const { data: { session } } = await supabase.auth.getSession();
-        const id = session?.user?.id ?? null;
-        setUserId(id);
-        if (!id) {
-          setLoading(false);
-          return;
-        }
-        const data = await CampaignsService.fetchCampaignsV2(id, currentWorkspaceId);
-        setCampaigns(data);
-      } catch (e) {
-        console.error('CampaignListSidebar load:', e);
-      } finally {
+  const loadCampaigns = useCallback(async () => {
+    setLoading(true);
+    setLoadError(false);
+    try {
+      const supabase = await getClientAsync();
+      const { data: { session } } = await supabase.auth.getSession();
+      const id = session?.user?.id ?? null;
+      setUserId(id);
+      if (!id) {
         setLoading(false);
+        return;
       }
-    };
-    run();
+      const data = await CampaignsService.fetchCampaignsV2(id, currentWorkspaceId);
+      setCampaigns(data);
+    } catch (e) {
+      console.error('CampaignListSidebar load:', e);
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
   }, [currentWorkspaceId]);
+
+  useEffect(() => {
+    void loadCampaigns();
+  }, [loadCampaigns]);
 
   const byStatus = useMemo(() => {
     const active = campaigns.filter((c) => ACTIVE_STATUSES.includes(c.status));
@@ -158,6 +163,16 @@ export function CampaignListSidebar({
             <Plus className="w-3.5 h-3.5" />
           </Button>
         </div>
+        {loadError && !loading && campaigns.length === 0 ? (
+          <div className="mt-3 rounded-md border border-destructive/30 bg-destructive/10 p-2 text-xs text-destructive">
+            <div className="flex items-center justify-between gap-2">
+              <span>Could not load campaigns.</span>
+              <Button size="sm" variant="outline" onClick={() => void loadCampaigns()}>
+                Retry
+              </Button>
+            </div>
+          </div>
+        ) : null}
       </div>
 
       <div className="flex-1 flex flex-col min-h-0 px-2 pt-2">

--- a/components/farms/FarmListSidebar.tsx
+++ b/components/farms/FarmListSidebar.tsx
@@ -39,6 +39,7 @@ export function FarmListSidebar({
   const { currentWorkspaceId } = useWorkspace();
   const [farms, setFarms] = useState<Farm[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [statusTab, setStatusTab] = useState<StatusTab>('active');
@@ -58,29 +59,33 @@ export function FarmListSidebar({
     [pathname, router]
   );
 
-  useEffect(() => {
-    const run = async () => {
-      try {
-        const supabase = await getClientAsync();
-        const {
-          data: { session },
-        } = await supabase.auth.getSession();
-        const id = session?.user?.id ?? null;
-        setUserId(id);
-        if (!id) {
-          setLoading(false);
-          return;
-        }
-        const data = await FarmService.fetchFarms(id, currentWorkspaceId);
-        setFarms(data);
-      } catch (error) {
-        console.error('FarmListSidebar load:', error);
-      } finally {
+  const loadFarms = useCallback(async () => {
+    setLoading(true);
+    setLoadError(false);
+    try {
+      const supabase = await getClientAsync();
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      const id = session?.user?.id ?? null;
+      setUserId(id);
+      if (!id) {
         setLoading(false);
+        return;
       }
-    };
-    run();
+      const data = await FarmService.fetchFarms(id, currentWorkspaceId);
+      setFarms(data);
+    } catch (error) {
+      console.error('FarmListSidebar load:', error);
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
   }, [currentWorkspaceId]);
+
+  useEffect(() => {
+    void loadFarms();
+  }, [loadFarms]);
 
   const byStatus = useMemo(() => {
     const active = farms.filter(isActiveFarm);
@@ -152,6 +157,16 @@ export function FarmListSidebar({
             <Plus className="w-3.5 h-3.5" />
           </Button>
         </div>
+        {loadError && !loading && farms.length === 0 ? (
+          <div className="mt-3 rounded-md border border-destructive/30 bg-destructive/10 p-2 text-xs text-destructive">
+            <div className="flex items-center justify-between gap-2">
+              <span>Could not load farms.</span>
+              <Button size="sm" variant="outline" onClick={() => void loadFarms()}>
+                Retry
+              </Button>
+            </div>
+          </div>
+        ) : null}
       </div>
 
       <div className="flex-1 flex flex-col min-h-0 px-2 pt-2">


### PR DESCRIPTION
## What this does
Adds three layers of error handling that were completely absent from 
the codebase. Previously any unhandled render error caused a white 
screen with no recovery path, and any data fetch failure was silent 
or indistinguishable from empty state.

## Changes

**Error boundaries (Next.js App Router error.tsx convention)**
- app/global-error.tsx, root fallback for any error that escapes 
  all other boundaries
- app/(main)/error.tsx, catches errors within the main authenticated 
  layout, preserves nav sidebar
- app/(main)/campaigns/error.tsx, campaign-specific error UI with 
  "Try again" and "All campaigns" buttons
- app/farms/error.tsx, farm-specific error UI with "Try again" and 
  "All farms" buttons

**Loading skeletons**
- app/(main)/campaigns/[campaignId]/loading.tsx, pulse skeleton 
  while campaign detail page loads
- app/farms/[id]/loading.tsx, pulse skeleton while farm detail loads

**User-facing error states for data fetch failures**
- Campaign detail: distinguishes between "Campaign not found" (404/
  PGRST116) and "Failed to load campaign" (real fetch error) with 
  Try again button
- Farm detail: same pattern
- Campaign list sidebar: inline "Could not load campaigns." with 
  Retry button when fetch fails
- Farm list sidebar: inline "Could not load farms." with Retry button

## Verified
- npx tsc --noEmit: 0 errors
- npm run build: 0 errors
- Error boundary tested manually with throw new Error(), shows 
  correct UI
- Invalid campaign URL shows "Campaign not found"
- Real fetch failure shows "Failed to load campaign" with Try again