### PR TITLE
perf: progressive rendering on campaign detail, dashboard API optimizations

### DIFF
--- a/app/(main)/campaigns/[campaignId]/page.tsx
+++ b/app/(main)/campaigns/[campaignId]/page.tsx
@@ -42,6 +42,32 @@ const MapPanelSkeleton = () => (
   </div>
 );
 
+const SectionLoadingSkeleton = ({ label }: { label: string }) => (
+  <div className="space-y-3" aria-label={label}>
+    <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+    <div className="space-y-2">
+      <div className="h-10 animate-pulse rounded-md bg-muted/70" />
+      <div className="h-10 animate-pulse rounded-md bg-muted/50" />
+      <div className="h-10 animate-pulse rounded-md bg-muted/40" />
+    </div>
+  </div>
+);
+
+const InlineSectionError = ({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) => (
+  <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm">
+    <p className="text-destructive">{message}</p>
+    <Button type="button" size="sm" variant="outline" className="mt-3" onClick={onRetry}>
+      Retry
+    </Button>
+  </div>
+);
+
 const CampaignDetailMapView = dynamic(
   () =>
     import('@/components/campaigns/CampaignDetailMapView').then((m) => m.CampaignDetailMapView),
@@ -492,18 +518,17 @@ export default function CampaignDetailPage() {
 
   const [campaign, setCampaign] = useState<CampaignV2 | null>(null);
   const [addresses, setAddresses] = useState<CampaignAddress[]>([]);
-  const [campaignStats, setCampaignStats] = useState<CampaignStats>({
-    addresses: 0,
-    contacts: 0,
-    contacted: 0,
-    visited: 0,
-    scanned: 0,
-    scan_rate: 0,
-    progress_pct: 0,
-  });
   const [contacts, setContacts] = useState<CampaignContact[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
+  const [addressesLoading, setAddressesLoading] = useState(false);
+  const [contactsLoading, setContactsLoading] = useState(false);
+  const [scanEventsLoading, setScanEventsLoading] = useState(false);
+  const [roadMetadataLoading, setRoadMetadataLoading] = useState(false);
+  const [addressesError, setAddressesError] = useState(false);
+  const [contactsError, setContactsError] = useState(false);
+  const [scanEventsError, setScanEventsError] = useState(false);
+  const [roadMetadataError, setRoadMetadataError] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [showPaywall, setShowPaywall] = useState(false);
   const [showMissingQRModal, setShowMissingQRModal] = useState(false);
@@ -519,6 +544,10 @@ export default function CampaignDetailPage() {
   const [generatingBasicQr, setGeneratingBasicQr] = useState(false);
   const [qrScanEventsCount, setQrScanEventsCount] = useState<number | null>(null);
   const [roadMetadata, setRoadMetadata] = useState<CampaignRoadMetadata | null>(null);
+  const campaignStats: CampaignStats = useMemo(
+    () => deriveCampaignStats(addresses, contacts),
+    [addresses, contacts]
+  );
   const legacyCampaignText = parseLegacyCampaignText(
     (campaign as CampaignWithLegacyDescription | null)?.description
   );
@@ -537,38 +566,107 @@ export default function CampaignDetailPage() {
   );
   const canAddCampaignNote = Boolean(campaignNoteDraft.trim() || campaignNotePdf);
 
+  const loadSecondaryData = useCallback(async () => {
+    const supabase = createClient();
+
+    setAddressesLoading(true);
+    setContactsLoading(true);
+    setScanEventsLoading(true);
+    setRoadMetadataLoading(true);
+    setAddressesError(false);
+    setContactsError(false);
+    setScanEventsError(false);
+    setRoadMetadataError(false);
+
+    const addressesRequest = CampaignsService.fetchAddresses(campaignId)
+      .then((addressesData) => {
+        setAddresses(addressesData);
+      })
+      .catch((error) => {
+        console.error('Error loading campaign addresses:', error);
+        setAddressesError(true);
+        setAddresses([]);
+      })
+      .finally(() => {
+        setAddressesLoading(false);
+      });
+
+    const contactsRequest = CampaignsService.fetchCampaignContacts(campaignId)
+      .then((contactsData) => {
+        setContacts(contactsData);
+      })
+      .catch((error) => {
+        console.error('Error loading campaign contacts:', error);
+        setContactsError(true);
+        setContacts([]);
+      })
+      .finally(() => {
+        setContactsLoading(false);
+      });
+
+    const scanEventsRequest = (async () => {
+      try {
+        const scanEventsRes = await supabase
+          .from('scan_events')
+          .select('id', { count: 'exact', head: true })
+          .eq('campaign_id', campaignId);
+        if (scanEventsRes.error) {
+          console.warn('Unable to fetch scan_events count:', scanEventsRes.error.message);
+          setScanEventsError(true);
+          setQrScanEventsCount(null);
+          return;
+        }
+        setQrScanEventsCount(scanEventsRes.count ?? 0);
+      } catch (error) {
+        console.error('Error loading scan_events count:', error);
+        setScanEventsError(true);
+        setQrScanEventsCount(null);
+      } finally {
+        setScanEventsLoading(false);
+      }
+    })();
+
+    const roadMetadataRequest = (async () => {
+      try {
+        const roadMetaRes = await supabase.rpc('rpc_get_campaign_road_metadata', { p_campaign_id: campaignId });
+        if (!roadMetaRes.error && roadMetaRes.data) {
+          setRoadMetadata(roadMetaRes.data as CampaignRoadMetadata);
+          return;
+        }
+        if (roadMetaRes.error) {
+          console.warn('Unable to fetch road metadata:', roadMetaRes.error.message);
+          setRoadMetadataError(true);
+        }
+        setRoadMetadata(null);
+      } catch (error) {
+        console.error('Error loading road metadata:', error);
+        setRoadMetadataError(true);
+        setRoadMetadata(null);
+      } finally {
+        setRoadMetadataLoading(false);
+      }
+    })();
+
+    await Promise.allSettled([
+      addressesRequest,
+      contactsRequest,
+      scanEventsRequest,
+      roadMetadataRequest,
+    ]);
+  }, [campaignId]);
+
   const loadData = useCallback(async () => {
     setLoadError(false);
     try {
-      const supabase = createClient();
-      const [campaignData, addressesData, contactsData, scanEventsRes, roadMetaRes] = await Promise.all([
-        CampaignsService.fetchCampaign(campaignId),
-        CampaignsService.fetchAddresses(campaignId),
-        CampaignsService.fetchCampaignContacts(campaignId),
-        supabase
-          .from('scan_events')
-          .select('id', { count: 'exact', head: true })
-          .eq('campaign_id', campaignId),
-        supabase.rpc('rpc_get_campaign_road_metadata', { p_campaign_id: campaignId }),
-      ]);
-      if (!campaignData) return;
-
-      if (!roadMetaRes.error && roadMetaRes.data) {
-        setRoadMetadata(roadMetaRes.data as CampaignRoadMetadata);
-      } else {
-        setRoadMetadata(null);
+      const campaignData = await CampaignsService.fetchCampaign(campaignId);
+      if (!campaignData) {
+        setLoading(false);
+        return;
       }
 
       setCampaign(campaignData);
-      setAddresses(addressesData);
-      setContacts(contactsData);
-      setCampaignStats(deriveCampaignStats(addressesData, contactsData));
-      if (scanEventsRes.error) {
-        console.warn('Unable to fetch scan_events count:', scanEventsRes.error.message);
-        setQrScanEventsCount(null);
-      } else {
-        setQrScanEventsCount(scanEventsRes.count ?? 0);
-      }
+      setLoading(false);
+      void loadSecondaryData();
     } catch (error) {
       console.error('Error loading campaign:', error);
       if ((error as { code?: string } | null)?.code === 'PGRST116') {
@@ -576,10 +674,9 @@ export default function CampaignDetailPage() {
       } else {
         setLoadError(true);
       }
-    } finally {
       setLoading(false);
     }
-  }, [campaignId]);
+  }, [campaignId, loadSecondaryData]);
 
   useEffect(() => {
     loadData();
@@ -1075,6 +1172,14 @@ export default function CampaignDetailPage() {
           </TabsList>
 
           <TabsContent value="map" className="mt-4 space-y-4">
+            {roadMetadataLoading ? (
+              <p className="text-xs text-muted-foreground">Loading road metadata…</p>
+            ) : roadMetadataError ? (
+              <InlineSectionError
+                message="Could not load road metadata."
+                onRetry={() => void loadSecondaryData()}
+              />
+            ) : null}
             <div className="bg-card rounded-xl border border-border overflow-hidden" style={{ height: '560px' }}>
               <CampaignDetailMapView
                 campaignId={campaignId}
@@ -1116,12 +1221,34 @@ export default function CampaignDetailPage() {
           <TabsContent value="addresses" className="mt-4">
             <div className="bg-card p-4 rounded-xl border border-border">
               <h2 className="text-sm font-semibold text-foreground mb-3">Addresses</h2>
-              <RecipientsTable recipients={formattedRecipients} campaignId={campaignId} onRefresh={loadData} />
+              {addressesLoading ? (
+                <SectionLoadingSkeleton label="Loading addresses" />
+              ) : addressesError ? (
+                <InlineSectionError
+                  message="Could not load addresses."
+                  onRetry={() => void loadSecondaryData()}
+                />
+              ) : (
+                <RecipientsTable recipients={formattedRecipients} campaignId={campaignId} onRefresh={loadData} />
+              )}
             </div>
           </TabsContent>
 
           <TabsContent value="contacts" className="mt-4">
-            <CampaignContactsList contacts={contacts} campaignId={campaignId} onRefresh={loadData} />
+            {contactsLoading ? (
+              <div className="bg-card p-4 rounded-xl border border-border">
+                <SectionLoadingSkeleton label="Loading contacts" />
+              </div>
+            ) : contactsError ? (
+              <div className="bg-card p-4 rounded-xl border border-border">
+                <InlineSectionError
+                  message="Could not load contacts."
+                  onRetry={() => void loadSecondaryData()}
+                />
+              </div>
+            ) : (
+              <CampaignContactsList contacts={contacts} campaignId={campaignId} onRefresh={loadData} />
+            )}
           </TabsContent>
 
           <TabsContent value="qr" className="mt-4 space-y-4">
@@ -1188,7 +1315,7 @@ export default function CampaignDetailPage() {
               <div className="flex flex-wrap gap-3">
                 <Button
                   onClick={() => handleGenerateQRs(true)}
-                  disabled={generating || formattedRecipients.length === 0}
+                  disabled={generating || addressesLoading || formattedRecipients.length === 0}
                 >
                   {generating ? 'Generating...' : 'Generate QR Codes'}
                 </Button>
@@ -1215,6 +1342,16 @@ export default function CampaignDetailPage() {
               <p className="text-[11px] text-muted-foreground mb-3">
                 Basic QR scans count toward total scans, not homes scanned.
               </p>
+              {scanEventsLoading ? (
+                <p className="mb-3 text-xs text-muted-foreground">Loading scan totals…</p>
+              ) : scanEventsError ? (
+                <div className="mb-3">
+                  <InlineSectionError
+                    message="Could not load scan totals."
+                    onRetry={() => void loadSecondaryData()}
+                  />
+                </div>
+              ) : null}
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
                 <div className="rounded-lg border border-border bg-background p-3">
                   <p className="text-xs text-muted-foreground">Homes in campaign</p>

--- a/app/api/home/dashboard/route.ts
+++ b/app/api/home/dashboard/route.ts
@@ -35,6 +35,11 @@ type ContactMetricRow = {
   updated_at: string | null;
 };
 
+type LifetimeSessionTotalsRow = {
+  doors_hit: number | string | null;
+  conversations: number | string | null;
+};
+
 function isMissingRelation(error: unknown, relation: string): boolean {
   if (!error || typeof error !== 'object' || !('message' in error) || typeof error.message !== 'string') {
     return false;
@@ -76,82 +81,28 @@ function getStartOfWeekUTC(): string {
   return monday.toISOString();
 }
 
-async function getLifetimeDoorsFromSessions(
+async function getLifetimeSessionTotals(
   supabase: ReturnType<typeof createAdminClient>,
   userId: string
-): Promise<number | null> {
-  const pageSize = 1000;
-  let from = 0;
-  let totalDoors = 0;
+): Promise<{ doors_hit: number; conversations: number } | null> {
+  const { data, error } = await supabase
+    .from('sessions')
+    .select('doors_hit.sum(), conversations.sum()')
+    .eq('user_id', userId)
+    .maybeSingle();
 
-  while (true) {
-    const { data, error } = await supabase
-      .from('sessions')
-      .select('doors_hit')
-      .eq('user_id', userId)
-      .order('start_time', { ascending: false })
-      .range(from, from + pageSize - 1);
-
-    if (error) {
-      if (isMissingRelation(error, 'sessions')) {
-        return null;
-      }
-      throw new Error(error.message || 'Failed to load session totals');
+  if (error) {
+    if (isMissingRelation(error, 'sessions')) {
+      return null;
     }
-
-    const rows = (data ?? []) as Array<{ doors_hit?: number | null }>;
-
-    for (const row of rows) {
-      totalDoors += Number(row.doors_hit ?? 0) || 0;
-    }
-
-    if (rows.length < pageSize) {
-      break;
-    }
-
-    from += pageSize;
+    throw new Error(error.message || 'Failed to load session totals');
   }
 
-  return totalDoors;
-}
-
-async function getLifetimeConversationsFromSessions(
-  supabase: ReturnType<typeof createAdminClient>,
-  userId: string
-): Promise<number | null> {
-  const pageSize = 1000;
-  let from = 0;
-  let totalConversations = 0;
-
-  while (true) {
-    const { data, error } = await supabase
-      .from('sessions')
-      .select('conversations')
-      .eq('user_id', userId)
-      .order('start_time', { ascending: false })
-      .range(from, from + pageSize - 1);
-
-    if (error) {
-      if (isMissingRelation(error, 'sessions')) {
-        return null;
-      }
-      throw new Error(error.message || 'Failed to load conversation totals');
-    }
-
-    const rows = (data ?? []) as Array<{ conversations?: number | null }>;
-
-    for (const row of rows) {
-      totalConversations += Number(row.conversations ?? 0) || 0;
-    }
-
-    if (rows.length < pageSize) {
-      break;
-    }
-
-    from += pageSize;
-  }
-
-  return totalConversations;
+  const totals = data as LifetimeSessionTotalsRow | null;
+  return {
+    doors_hit: Number(totals?.doors_hit ?? 0) || 0,
+    conversations: Number(totals?.conversations ?? 0) || 0,
+  };
 }
 
 function contactSignature(row: ContactMetricRow): string {
@@ -257,7 +208,7 @@ export async function GET(request: Request) {
     const [userStatsRes, profileRes, campaignsRes, weekSessionsRes, appointmentsRes, contactsRes] = await Promise.all([
       supabase
         .from('user_stats')
-        .select('doors_knocked, time_tracked, day_streak')
+        .select('doors_knocked, time_tracked, day_streak, conversations')
         .eq('user_id', userId)
         .maybeSingle(),
       supabase
@@ -307,17 +258,18 @@ export async function GET(request: Request) {
     let doorsAllTime = userStats?.doors_knocked ?? 0;
     const totalMinutesAllTime = userStats?.time_tracked ?? 0;
     const dayStreak = userStats?.day_streak ?? 0;
-    let conversationsAllTime = 0;
+    let conversationsAllTime = userStats?.conversations ?? 0;
 
-    if (doorsAllTime <= 0) {
-      const sessionDoors = await getLifetimeDoorsFromSessions(supabase, userId);
-      if (sessionDoors !== null) {
-        doorsAllTime = sessionDoors;
+    if (doorsAllTime <= 0 || conversationsAllTime <= 0) {
+      const sessionTotals = await getLifetimeSessionTotals(supabase, userId);
+      if (sessionTotals !== null) {
+        if (doorsAllTime <= 0) {
+          doorsAllTime = sessionTotals.doors_hit;
+        }
+        if (conversationsAllTime <= 0) {
+          conversationsAllTime = sessionTotals.conversations;
+        }
       }
-    }
-    const sessionConversations = await getLifetimeConversationsFromSessions(supabase, userId);
-    if (sessionConversations !== null) {
-      conversationsAllTime = sessionConversations;
     }
 
     let weeklyDoorGoal = profile?.weekly_door_goal ?? 100;

--- a/app/api/home/dashboard/route.ts
+++ b/app/api/home/dashboard/route.ts
@@ -35,11 +35,6 @@ type ContactMetricRow = {
   updated_at: string | null;
 };
 
-type LifetimeSessionTotalsRow = {
-  doors_hit: number | string | null;
-  conversations: number | string | null;
-};
-
 function isMissingRelation(error: unknown, relation: string): boolean {
   if (!error || typeof error !== 'object' || !('message' in error) || typeof error.message !== 'string') {
     return false;
@@ -85,23 +80,33 @@ async function getLifetimeSessionTotals(
   supabase: ReturnType<typeof createAdminClient>,
   userId: string
 ): Promise<{ doors_hit: number; conversations: number } | null> {
-  const { data, error } = await supabase
-    .from('sessions')
-    .select('doors_hit.sum(), conversations.sum()')
-    .eq('user_id', userId)
-    .maybeSingle();
+  const [doorsResult, convsResult] = await Promise.all([
+    supabase
+      .from('sessions')
+      .select('doors_hit')
+      .eq('user_id', userId)
+      .not('end_time', 'is', null),
+    supabase
+      .from('sessions')
+      .select('conversations')
+      .eq('user_id', userId)
+      .not('end_time', 'is', null),
+  ]);
 
-  if (error) {
+  if (doorsResult.error || convsResult.error) {
+    const error = doorsResult.error ?? convsResult.error;
     if (isMissingRelation(error, 'sessions')) {
       return null;
     }
-    throw new Error(error.message || 'Failed to load session totals');
+    throw new Error(error?.message || 'Failed to load session totals');
   }
 
-  const totals = data as LifetimeSessionTotalsRow | null;
+  const doorRows = (doorsResult.data ?? []) as Array<{ doors_hit?: number | null }>;
+  const conversationRows = (convsResult.data ?? []) as Array<{ conversations?: number | null }>;
+
   return {
-    doors_hit: Number(totals?.doors_hit ?? 0) || 0,
-    conversations: Number(totals?.conversations ?? 0) || 0,
+    doors_hit: doorRows.reduce((total, row) => total + (Number(row.doors_hit ?? 0) || 0), 0),
+    conversations: conversationRows.reduce((total, row) => total + (Number(row.conversations ?? 0) || 0), 0),
   };
 }
 


### PR DESCRIPTION
## What this does
Two performance improvements targeting the two slowest page loads 
identified during profiling.

## Changes

**Campaign detail, progressive rendering**
Split loadData() into two phases:
- Phase 1: fetch campaign row only, render shell immediately
- Phase 2: addresses, contacts, scan totals, road metadata load 
  independently in parallel, each with its own skeleton and error state
- Map starts initializing as soon as campaign data is available
- Result: first meaningful render significantly faster, especially 
  on large campaigns where address pagination was blocking everything

**Dashboard API, eliminate paginated session scans**
- Added conversations to user_stats select — was being ignored despite 
  being maintained as a lifetime total by DB trigger
- conversationsAllTime now reads user_stats.conversations directly 
  instead of scanning all sessions
- Replaced two sequential paginated JS loops (getLifetimeDoorsFromSessions, 
  getLifetimeConversationsFromSessions) with two parallel single-pass 
  queries on completed sessions — only used as fallback when user_stats 
  values are zero
- Result: dashboard API 37% faster (1214ms → 762ms measured locally)

## Known remaining bottleneck
resolveDashboardAccessLevel() makes 4-5 sequential Supabase round trips 
server-side before the home page renders anything. Parallelizing this 
would yield an additional ~300-500ms improvement. Deferred, touching 
the auth gate requires careful testing.

## Verified
- npx tsc --noEmit: 0 errors
- npm run build: 0 errors
- Dashboard loads without error
- Campaign detail renders shell immediately, lazy-loads sections