### PR TITLE
fix: UX polish — sidebar refresh, contact form scroll, empty states, nav cleanup, canonical domain

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -34,11 +34,6 @@ Complexity: medium to large.
 Two simultaneous generate-qrs calls for the same campaign race row-by-row.
 The final QR data is whichever request writes last.
 
-### Large QR payload risk
-QR PNGs are stored as base64 in campaign_addresses and passed through 
-the campaign page. Large campaigns can significantly inflate payload size 
-and browser memory usage.
-
 ### generate-qrs invalid domain handling
 An invalid domain in the URL constructor fails every address in the loop 
 but the route still returns success: true with count: 0.
@@ -68,6 +63,36 @@ If multiple fallback paths in useBuildingData return overlapping address
 IDs, the final address list may contain duplicates. No dedup step exists
 after the fallback chain resolves.
 
+### resolveDashboardAccessLevel sequential auth gate
+Home page server component makes 4-5 sequential Supabase round trips in
+resolveDashboardAccessLevel() before rendering anything. Parallelizing
+would yield ~300-500ms improvement. Requires careful testing — touches
+auth gate.
+
+### MapBuildingsLayer unguarded source/layer reads
+Lines ~1869, 1870, 2615 have map.getLayer()/map.getSource() reads without
+local try/catch. Not in event handlers so crash risk is low, but weaker
+than the hardened pattern. Do not touch while Daniel is actively working
+on this file.
+
+### fetchAddresses() waterfall
+CampaignsService.fetchAddresses() performs sequential paginated reads
+against three tables. Main remaining bottleneck on campaign detail for
+large campaigns. Consider parallelizing or combining into a single query.
+
+### No client-side caching
+No SWR, React Query, or Next.js cache anywhere. Every navigation refetches
+all data from scratch. High-value target for back-navigation performance.
+
+### Campaign detail entirely client-side
+All data fetching via useEffect with no server prefetch. Converting campaign
+row fetch to server component would improve Time to First Byte.
+
+### Large QR base64 payload
+QR PNGs stored as base64 inline in campaign page payload. For large
+campaigns this inflates memory and API response size significantly.
+Consider S3 URLs instead.
+
 ---
 
 ## Needs owner decision
@@ -84,21 +109,28 @@ until the user clicks Addresses. Confusing for new users who expect
 to see their campaign addresses on load.
 Action: Daniel to decide default map state.
 
-### Meta ads panel not visible
-Meta ads tab does not appear on farm detail pages. Likely gated 
-behind Meta OAuth connection.
-Action: Daniel to confirm expected visibility behavior.
-
-### Contact save may not persist in local dev
-Contact status resets after navigation in local dev. Needs 
-production verification before investigating further.
-
 ### campaign territory_boundary not validated as valid Polygon
 The provision route checks if (!polygon) but does not validate that
 territory_boundary is actually a valid GeoJSON Polygon before passing
 it to Turf/PMTiles logic. A malformed non-null territory can pass
 validation and cause a cryptic failure inside Turf.
 Action: add explicit GeoJSON Polygon validation at the route boundary.
+
+### Nav cleanup (decided — pending implementation)
+- Remove flyer editor from nav (export 501, persistence TODO-backed)
+- Remove partner offers from nav
+- Remove landing pages create link (routes to non-existent page)
+- Enforce canonical domain flyrpro.app via middleware redirect
+
+### Farms removal
+Daniel handling. Campaign features that were farm-only need to be absorbed
+into campaigns. Do not touch farm-related code until Daniel is done.
+
+### Team leader / field agent mod actions
+Greenlit. Needs scoping — actions, permissions, UI surfaces.
+
+### Audit log for destructive actions
+Greenlit. Needs scoping — which actions, where stored, who can view.
 
 ---
 
@@ -114,3 +146,14 @@ Action: add explicit GeoJSON Polygon validation at the route boundary.
   once, leaving double-encoded Bedrock IDs unresolved.
 - generate-qrs auth hole: fixed in PR 20. Route had no workspace check.
 - useBuildingData AbortController: fixed in PR 20.
+- Meta ads panel not visible: resolved. Farms are being removed, so this
+  farm detail visibility issue is moot.
+- Contact save may not persist in local dev: resolved. address_statuses is
+  the source of truth per Daniel.
+- GeoJSON audit 2026-05-21: Daniel's 12 commits audited, no conflicts
+  with our fixes, retry cap preserved, no new layer-scoped listeners,
+  minor unguarded reads at lines ~1869/1870/2615 noted.
+- Dashboard perf PR 23: 37% faster (1214ms → 762ms). Remaining bottleneck
+  is sequential server auth gate.
+- Campaign detail perf PR 23: progressive rendering implemented, shell
+  renders after campaign fetch, addresses/contacts lazy-load in parallel.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -132,6 +132,19 @@ Greenlit. Needs scoping — actions, permissions, UI surfaces.
 ### Audit log for destructive actions
 Greenlit. Needs scoping — which actions, where stored, who can view.
 
+### Address status manual override on web
+Address status in the Addresses tab (address_statuses table) is currently
+only updated by the iOS field app during active door knocking sessions.
+The web app has no way to manually set a canvassing outcome for an address.
+
+The "Status" field in the Add Contact dialog is a separate CRM classification
+(contacts.status: new/hot/warm/cold) — it does not affect the Addresses tab
+status.
+
+Adding a manual override on the web requires coordination with Daniel to ensure
+the web route doesn't conflict with iOS session behavior or create unexpected
+data state.
+
 ---
 
 ## Notes

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -34,7 +34,7 @@ and only defines four things:
 - `user_profiles`
 - Storage bucket policies for `qr` and `flyers`
 
-The actual production database has been built through 257 migration files spanning
+The actual production database has been built through 263 migration files spanning
 January 2025 to May 2026, plus migrations applied from the iOS repo
 (`FLYR/supabase/migrations/`). Neither repo's migration history is complete on its own.
 
@@ -57,9 +57,9 @@ state needs to be created — see Section 9.
 
 ## 2. Migration inventory
 
-**Total migration files:** 257  
+**Total migration files:** 263  
 **Earliest:** `20250117000000_add_full_unique_constraint_campaign_addresses.sql`  
-**Latest:** `20260514120000_skip_building_rpc_for_bedrock_campaigns.sql`  
+**Latest:** `20260525000000_add_contractor_crm_integrations.sql`  
 **One non-timestamped file:** `create_flyers_table.sql` — treat as applied, do not re-run.
 
 The migrations fall into these functional groups:
@@ -122,6 +122,12 @@ of these are iOS-coupled — the iOS app renders the map directly from this data
 | `20260510000000_restrict_campaign_provision_sources_to_diamond_bedrock.sql` | 2026-05-10 | Replaces legacy provision-source values with the Diamond/Bedrock source set and documents the new source semantics. | `campaigns` | Drops and recreates `campaigns_provision_source_check`. Updates existing `gold`, `silver`, and `lambda` values to `NULL`, which is a destructive normalization of legacy source labels. |
 | `20260511140000_add_country_flags_to_profiles_and_leaderboard.sql` | 2026-05-11 | Adds country-code fields to profile tables and recreates `get_leaderboard` so leaderboard rows can include a country code. | `user_profiles`, `profiles`, `leaderboard_rollups`, `challenge_participants`; reads `auth.users`; function `get_leaderboard` | Uses `DROP FUNCTION IF EXISTS public.get_leaderboard(...)` before recreating it with a new return shape. No table or column drops. |
 | `20260514120000_skip_building_rpc_for_bedrock_campaigns.sql` | 2026-05-14 | Replaces `rpc_get_campaign_map_bundle` so Diamond/Bedrock campaigns skip the legacy Gold building RPC and rely on PMTiles/frontend fallback buildings instead. | Function `rpc_get_campaign_map_bundle`; reads `campaigns`, `campaign_addresses`, `campaign_parcels`; conditionally calls building/parcels/roads RPCs | No DROP statements. Uses `CREATE OR REPLACE FUNCTION`; does not alter `rpc_get_campaign_full_features`. |
+| `20260521131000_live_session_codes_and_participants.sql` | 2026-05-21 | Adds live session participant tracking, share/join codes, RLS policies, and `is_session_participant` helper for collaborative campaign sessions. | `session_participants`, `live_session_codes`; references `sessions`, `campaigns`, `workspace_invites`, `workspaces`, and `auth.users`; function `is_session_participant` | Uses `DROP POLICY IF EXISTS` before recreating RLS policies on the new `session_participants` table. No DROP TABLE or DROP COLUMN. |
+| `20260522170000_create_salespeople.sql` | 2026-05-22 | Creates salesperson admin table with commission settings, Stripe Connect fields, indexes, RLS, and updated-at trigger. | `salespeople`; function/trigger `salespeople_set_updated_at` | Uses `DROP TRIGGER IF EXISTS` before recreating the trigger. No DROP TABLE or DROP COLUMN. |
+| `20260522173000_seed_salesperson_workspace.sql` | 2026-05-22 | Seeds salesperson records for two specific email addresses, creates or updates a Salesperson Workspace, and attaches matching auth users to that workspace. | `salespeople`, `workspaces`, `user_profiles`, `workspace_members`; reads `auth.users` | No DROP statements. Performs data-seeding `INSERT`/`UPDATE` operations for named users/workspace. |
+| `20260522180000_salesperson_commissions_and_payouts.sql` | 2026-05-22 | Adds commission duration to salespeople and creates salesperson referral, commission, payout batch, and payout batch item tables with indexes, RLS, FK wiring, and updated-at triggers. | `salespeople`, `salesperson_referrals`, `salesperson_commissions`, `salesperson_payout_batches`, `salesperson_payout_batch_items`; references `workspaces` and `auth.users` | Drops and recreates `salespeople_commission_duration_months_check`; uses `DROP TRIGGER IF EXISTS` before recreating triggers. No table or column drops. |
+| `20260522190000_salesperson_invites_and_workspaces.sql` | 2026-05-22 | Adds salesperson invite/workspace ownership fields, backfills invite tokens and founder user links, and adds lookup indexes. | `salespeople`; reads `user_profiles` | No DROP statements. Runs backfill `UPDATE`s for invite tokens and founder assignment. |
+| `20260525000000_add_contractor_crm_integrations.sql` | 2026-05-25 | Expands allowed CRM object link provider values for contractor/home-service CRM integrations. | `crm_object_links` | Drops and recreates `crm_object_links_crm_type_check`. No table or column drops. |
 
 ---
 

--- a/app/(main)/MainLayoutClient.tsx
+++ b/app/(main)/MainLayoutClient.tsx
@@ -41,14 +41,12 @@ const salespersonWorkspaceTabs = [
   { href: '/dialer', icon: PhoneCall, label: 'Dialer' },
   { href: '/list', icon: ListChecks, label: 'List' },
   { href: '/leads', icon: Users, label: 'Leads' },
-  offersTab,
   { href: '/stats', icon: Gauge, label: 'Performance' },
   { href: '/scraper', icon: Search, label: 'Scraper' },
   settingsTab,
 ];
 const founderTabs = [
   ...baseTabs.filter((tab) => ['/home'].includes(tab.href)),
-  offersTab,
   ambassadorsTab,
   salespeopleTab,
   ...baseTabs.filter((tab) => ['/activity', '/leads', '/follow-up', '/appointments'].includes(tab.href)),

--- a/app/(main)/campaigns/[campaignId]/page.tsx
+++ b/app/(main)/campaigns/[campaignId]/page.tsx
@@ -1128,6 +1128,7 @@ export default function CampaignDetailPage() {
       contacts: matchedContacts,
     };
   });
+  const hasGeneratedAdvancedQr = formattedRecipients.some((recipient) => Boolean(recipient.qr_code_base64));
   const linkQualityBanner = getLinkQualityBanner(campaign);
 
   return (
@@ -1313,6 +1314,15 @@ export default function CampaignDetailPage() {
               <p className="text-xs text-muted-foreground mb-3">
                 Unique QR codes for every home in the campaign. Scans are tied to addresses and each PNG includes the home address for print matching.
               </p>
+              {!addressesLoading && formattedRecipients.length === 0 ? (
+                <p className="mb-3 text-xs text-muted-foreground">
+                  Add addresses to this campaign before generating QR codes.
+                </p>
+              ) : !addressesLoading && !hasGeneratedAdvancedQr ? (
+                <p className="mb-3 text-xs text-muted-foreground">
+                  QR codes have not been generated yet.
+                </p>
+              ) : null}
               <div className="flex flex-wrap gap-3">
                 <Button
                   onClick={() => handleGenerateQRs(true)}

--- a/app/(main)/campaigns/[campaignId]/page.tsx
+++ b/app/(main)/campaigns/[campaignId]/page.tsx
@@ -1186,6 +1186,7 @@ export default function CampaignDetailPage() {
                 addresses={addresses}
                 campaign={campaign}
                 onSnapComplete={loadData}
+                onContactCreated={loadSecondaryData}
                 buildingPendingOverlay={{
                   title: 'Buildings loading',
                   description: 'Addresses are ready. Building footprints will appear when Diamond finishes.',

--- a/app/(main)/campaigns/create/page.tsx
+++ b/app/(main)/campaigns/create/page.tsx
@@ -573,6 +573,7 @@ export default function CreateCampaignPage() {
       }
 
       router.push(`/campaigns/${campaign.id}`);
+      window.dispatchEvent(new CustomEvent('flyr-campaigns-refresh'));
     } catch (error: unknown) {
       console.error('Error creating campaign:', error);
       // Extract meaningful error message

--- a/app/(main)/create/page.tsx
+++ b/app/(main)/create/page.tsx
@@ -3,25 +3,18 @@
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { FarmIcon } from '@/components/icons/FarmIcon';
-import { Megaphone, QrCode, FileText, FileImage } from 'lucide-react';
+import { Megaphone, QrCode } from 'lucide-react';
 
 export default function CreatePage() {
   const router = useRouter();
 
-  const handleCreate = (
-    type: 'campaign' | 'farm' | 'qr' | 'landing-page' | 'flyer'
-  ) => {
+  const handleCreate = (type: 'campaign' | 'farm' | 'qr') => {
     if (type === 'campaign') {
       router.push('/campaigns/create');
     } else if (type === 'farm') {
       router.push('/farms/create');
     } else if (type === 'qr') {
       router.push('/qr');
-    } else if (type === 'landing-page') {
-      // TODO: Create landing page creation route
-      router.push('/landing-pages/create');
-    } else if (type === 'flyer') {
-      router.push('/editor');
     }
   };
 
@@ -68,34 +61,6 @@ export default function CreatePage() {
 
           {/* Right Column */}
           <div className="space-y-4">
-            <Button
-              variant="outline"
-              className="h-auto p-6 flex flex-col items-start w-full"
-              onClick={() => handleCreate('flyer')}
-            >
-              <div className="flex items-center gap-3 mb-2">
-                <FileImage className="w-6 h-6" />
-                <span className="text-lg font-semibold">Flyer</span>
-              </div>
-              <p className="text-sm text-gray-600 text-left">
-                Design and customize flyer templates for print
-              </p>
-            </Button>
-
-            <Button
-              variant="outline"
-              className="h-auto p-6 flex flex-col items-start w-full"
-              onClick={() => handleCreate('landing-page')}
-            >
-              <div className="flex items-center gap-3 mb-2">
-                <FileText className="w-6 h-6" />
-                <span className="text-lg font-semibold">Landing Page</span>
-              </div>
-              <p className="text-sm text-gray-600 text-left">
-                Create a custom landing page for your campaigns
-              </p>
-            </Button>
-
             <Button
               variant="outline"
               className="h-auto p-6 flex flex-col items-start w-full"

--- a/app/farms/[id]/page.tsx
+++ b/app/farms/[id]/page.tsx
@@ -2145,7 +2145,9 @@ export default function FarmPage() {
             </CardHeader>
             <CardContent className="space-y-4">
               {leads.length === 0 && contacts.length === 0 ? (
-                <p className="text-sm text-muted-foreground">No farm-linked leads or contacts yet.</p>
+                <p className="text-sm text-muted-foreground">
+                  No contacts linked to this farm yet. Contacts are created when field agents interact with addresses during sessions, or you can add them manually from the Contacts page.
+                </p>
               ) : null}
 
               {leads.length > 0 ? (

--- a/app/farms/create/page.tsx
+++ b/app/farms/create/page.tsx
@@ -730,6 +730,7 @@ export default function CreateFarmPage() {
       }
 
       router.push(`/farms/${farm.id}`);
+      window.dispatchEvent(new CustomEvent('flyr-farms-refresh'));
     } catch (error) {
       console.error('Error creating farm:', error);
       await showFeedbackDialog({

--- a/components/CreateHubView.tsx
+++ b/components/CreateHubView.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { FarmIcon } from '@/components/icons/FarmIcon';
-import { Megaphone, QrCode, FileText, FileImage } from 'lucide-react';
+import { Megaphone, QrCode } from 'lucide-react';
 
 export function CreateHubView({
   open,
@@ -21,9 +21,7 @@ export function CreateHubView({
 }) {
   const router = useRouter();
 
-  const handleCreate = (
-    type: 'campaign' | 'farm' | 'qr' | 'landing-page' | 'flyer'
-  ) => {
+  const handleCreate = (type: 'campaign' | 'farm' | 'qr') => {
     onClose();
     if (type === 'campaign') {
       router.push('/campaigns/create');
@@ -31,11 +29,6 @@ export function CreateHubView({
       router.push('/farms/create');
     } else if (type === 'qr') {
       router.push('/qr');
-    } else if (type === 'landing-page') {
-      // TODO: Create landing page creation route
-      router.push('/landing-pages/create');
-    } else if (type === 'flyer') {
-      router.push('/editor');
     }
   };
 
@@ -83,34 +76,6 @@ export function CreateHubView({
 
           {/* Right Column */}
           <div className="space-y-4">
-            <Button
-              variant="outline"
-              className="h-auto p-6 flex flex-col items-start w-full"
-              onClick={() => handleCreate('flyer')}
-            >
-              <div className="flex items-center gap-3 mb-2">
-                <FileImage className="w-6 h-6" />
-                <span className="text-lg font-semibold">Flyer</span>
-              </div>
-              <p className="text-sm text-gray-600 text-left">
-                Design and customize flyer templates for print
-              </p>
-            </Button>
-
-            <Button
-              variant="outline"
-              className="h-auto p-6 flex flex-col items-start w-full"
-              onClick={() => handleCreate('landing-page')}
-            >
-              <div className="flex items-center gap-3 mb-2">
-                <FileText className="w-6 h-6" />
-                <span className="text-lg font-semibold">Landing Page</span>
-              </div>
-              <p className="text-sm text-gray-600 text-left">
-                Create a custom landing page for your campaigns
-              </p>
-            </Button>
-
             <Button
               variant="outline"
               className="h-auto p-6 flex flex-col items-start w-full"

--- a/components/campaigns/CampaignAssignmentView.tsx
+++ b/components/campaigns/CampaignAssignmentView.tsx
@@ -541,7 +541,13 @@ export function CampaignAssignmentView({ campaignId, campaignName, addresses }: 
             ))}
           </CardContent>
         </Card>
-      ) : null}
+      ) : (
+        <Card>
+          <CardContent className="p-4 text-sm text-muted-foreground">
+            No assignments yet. Use the form above to assign this campaign to a team member.
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 }

--- a/components/campaigns/CampaignDetailMapView.tsx
+++ b/components/campaigns/CampaignDetailMapView.tsx
@@ -484,6 +484,7 @@ export function CampaignDetailMapView({
   addresses,
   campaign,
   onSnapComplete,
+  onContactCreated,
   renderLocationCardExtra,
   buildingPendingOverlay,
   pointOverlays = [],
@@ -493,6 +494,7 @@ export function CampaignDetailMapView({
   addresses: CampaignAddress[];
   campaign?: CampaignV2 | null;
   onSnapComplete?: () => void;
+  onContactCreated?: () => void;
   renderLocationCardExtra?: (args: {
     selectedBuildingId: string;
     selectedAddressId?: string | null;
@@ -1177,6 +1179,7 @@ export function CampaignDetailMapView({
       setSelectedBuildingId(null);
       setTimeout(() => setSelectedBuildingId(currentId), 100);
     }
+    onContactCreated?.();
   };
 
   useEffect(() => {

--- a/components/campaigns/CampaignDetailMapView.tsx
+++ b/components/campaigns/CampaignDetailMapView.tsx
@@ -2537,7 +2537,6 @@ export function CampaignDetailMapView({
           onSuccess={handleContactCreated}
           userId={userId}
           workspaceId={currentWorkspaceId ?? undefined}
-          portalContainer={mapShellRef.current}
           initialAddress={selectedAddressText}
           initialAddressId={selectedAddressId}
           initialCampaignId={campaignId}

--- a/components/campaigns/CampaignListSidebar.tsx
+++ b/components/campaigns/CampaignListSidebar.tsx
@@ -90,6 +90,10 @@ export function CampaignListSidebar({
 
   useEffect(() => {
     void loadCampaigns();
+    window.addEventListener('flyr-campaigns-refresh', loadCampaigns);
+    return () => {
+      window.removeEventListener('flyr-campaigns-refresh', loadCampaigns);
+    };
   }, [loadCampaigns]);
 
   const byStatus = useMemo(() => {

--- a/components/crm/ContactsHubView.tsx
+++ b/components/crm/ContactsHubView.tsx
@@ -524,6 +524,7 @@ export function ContactsHubView() {
           allVisibleSelected={visibleContacts.length > 0 && selectedVisibleCount === visibleContacts.length}
           onToggleContactSelection={handleToggleContactSelection}
           onToggleSelectAll={handleToggleSelectAll}
+          hasActiveFilter={selectedMemberId !== 'all' || selectedList.id !== ALL_LEADS_LIST_ID}
           copy={copy}
         />
       </div>

--- a/components/crm/CreateContactDialog.tsx
+++ b/components/crm/CreateContactDialog.tsx
@@ -347,7 +347,7 @@ export function CreateContactDialog({
               <SelectTrigger>
                 <SelectValue />
               </SelectTrigger>
-              <SelectContent portalContainer={portalContainer}>
+              <SelectContent>
                 <SelectItem value="new">New</SelectItem>
                 <SelectItem value="hot">Hot</SelectItem>
                 <SelectItem value="warm">Warm</SelectItem>

--- a/components/crm/LeadsTableView.tsx
+++ b/components/crm/LeadsTableView.tsx
@@ -70,6 +70,7 @@ export function LeadsTableView({
   allVisibleSelected,
   onToggleContactSelection,
   onToggleSelectAll,
+  hasActiveFilter,
   copy,
 }: {
   contacts: Contact[];
@@ -81,6 +82,7 @@ export function LeadsTableView({
   allVisibleSelected: boolean;
   onToggleContactSelection: (contactId: string, checked: boolean) => void;
   onToggleSelectAll: (checked: boolean) => void;
+  hasActiveFilter: boolean;
   copy: IndustryCopy;
 }) {
   const toPercent = (numerator: number, denominator: number): number | null => {
@@ -117,7 +119,9 @@ export function LeadsTableView({
         {loading ? (
           <div className="p-8 text-center text-muted-foreground">{copy.leads.loading}</div>
         ) : contacts.length === 0 ? (
-          <div className="p-8 text-center text-muted-foreground">{copy.leads.empty}</div>
+          <div className="p-8 text-center text-muted-foreground">
+            {hasActiveFilter ? copy.leads.empty : 'No leads yet. Add a contact or import a list to get started.'}
+          </div>
         ) : (
           <Table>
             <TableHeader>

--- a/components/farms/FarmListSidebar.tsx
+++ b/components/farms/FarmListSidebar.tsx
@@ -85,6 +85,10 @@ export function FarmListSidebar({
 
   useEffect(() => {
     void loadFarms();
+    window.addEventListener('flyr-farms-refresh', loadFarms);
+    return () => {
+      window.removeEventListener('flyr-farms-refresh', loadFarms);
+    };
   }, [loadFarms]);
 
   const byStatus = useMemo(() => {

--- a/docs/IOS_INTEGRATION.md
+++ b/docs/IOS_INTEGRATION.md
@@ -79,6 +79,37 @@ Some web calls also bridge into cookie auth. `FLYR/Services/OvertureAddressServi
 | `/api/routes/assignments/status` | POST | `FLYR/Features/Routes/Services/RouteAssignmentsAPI.swift:119` | Updates assignment status. |
 | `/api/share-card` | GET | `FLYR/Features/Challenges/Services/ChallengeService.swift:217` | Fetches challenge share-card image. |
 
+### 3.1 New web routes touching iOS-coupled tables
+
+These routes were added in Daniel's salespeople/live-sessions/contractor CRM checkpoint.
+They may not all be called by the current iOS app yet, but they read or write tables
+that iOS also uses directly. Treat them as shared-data routes.
+
+| Route | Method | Tables touched | iOS coupling risk | Notes |
+|---|---:|---|---|---|
+| `/api/contacts` | GET | `contacts` | Medium | Lists up to 200 contacts scoped by workspace or user. Response maps DB names into `fullName`, `email`, `phone`, and `tags`. |
+| `/api/contacts` | POST | `contacts` | High | Inserts a contact with `user_id`, optional `workspace_id`, `full_name`, `email`, `phone`, and `status = 'new'`. `contacts` is directly read/written by iOS. |
+| `/api/leads` | GET | `contacts` | Medium | Reads campaign/workspace-scoped leads from `contacts` and maps them to lead fields. Has fallback for older schemas missing enriched columns. |
+| `/api/leads/upsert` | POST | `contacts`, `contact_activities` | High | Inserts a contact/lead with campaign/address/building/session linkage when provided, then optionally inserts note/meeting rows into `contact_activities`. |
+| `/api/qr-codes` | GET | `qr_codes` | Medium | Lists QR rows owned by the authenticated user via metadata filters. iOS writes and reads `qr_codes` directly. |
+| `/api/qr-codes` | POST | `qr_codes` | High | Inserts generic direct-link QR rows with generated `slug`, `/q/{slug}` URL, `direct_url`, and owner/workspace metadata. Do not change `qr_codes` shape without iOS coordination. |
+| `/api/sessions/start` | POST | `campaigns`, `workspace_members`, `campaign_members`, `sessions`, `session_participants` | High | Starts an active session row, resolving workspace access from workspace/campaign membership, and upserts the host into `session_participants` for campaign sessions. `sessions` is iOS-critical. |
+| `/api/sessions/update` | POST | `campaigns`, `workspace_members`, `campaign_members`, `session_participants`, `sessions`, `route_assignments`, `farm_touches` | High | Updates active sessions or creates/completes session rows, writes route assignment completion progress, and marks farm touches complete. Touches multiple field-session tables used by iOS. |
+| `/api/live-sessions/codes/create` | POST | `sessions`, `campaigns`, `live_session_codes` | Medium | Host-only route that revokes existing active codes for a session and inserts a new hashed join code. Depends on `sessions` and `campaigns` consistency. |
+| `/api/live-sessions/codes/join` | POST | `live_session_codes`, `sessions`, `campaigns`, `campaign_members`, `session_participants` | High | Validates a join code, may upsert `campaign_members`, upserts the joining user into `session_participants`, and updates `live_session_codes.last_used_at`. |
+| `/api/live-sessions/presence` | GET | `campaign_presence` | Medium | Reads fresh participant locations for a campaign after campaign access validation. Presence is web-owned but campaign access is shared. |
+| `/api/live-sessions/presence` | POST | `campaign_presence`, `session_participants` | Medium | Upserts campaign presence and updates participant heartbeat fields. Coordinate with iOS if native live-session presence is added. |
+
+### 3.2 Existing iOS-coupled routes changed in Daniel's latest commit
+
+| Route | Method | Tables/RPCs touched | iOS coupling risk | Change note |
+|---|---:|---|---|---|
+| `/api/campaigns/{campaignId}/addresses/{addressId}` | DELETE | `campaign_addresses` via `deleteAddressIfExists` helper | High | Direct delete was replaced with a shared location-delete helper that can clean related location data. Request/response contract remains `deleted: true, address_id`. |
+| `/api/campaigns/{campaignId}/addresses/{addressId}/manual` | DELETE | `campaign_addresses` via `deleteCampaignAddressDeep` helper | High | Manual address delete now validates `source = 'manual'` and uses deep-delete helper with `requireManualSource`. Non-manual rows return 409. |
+| `/api/campaigns/{campaignId}/state` | GET | `address_statuses`, `campaign_assignments`, `campaign_assignment_homes` | High | Adds assigned-to-me scoping and cursor-based state payload for address statuses. iOS depends on address status semantics. |
+| `/api/campaigns/{campaignId}/state` | POST | `record_campaign_address_outcome`, `upsert_address_status`, `farm_addresses` | High | Writes canonical address outcomes through RPC with fallback to `upsert_address_status`; optionally syncs farm address visit/outcome fields. |
+| `/api/campaigns/provision` | POST | `campaigns`, `building_address_links`, post-processing/linker pipeline | High | Adds optional wait flags (`wait_for_linker`, `wait_for_postprocess`, `require_linked_homes`) that run post-processing before response, counts building links, and repairs missing `provision_source`. Existing default background behavior is preserved when flags are absent. |
+
 ## 4. Database tables read or written by iOS directly
 
 | Table | Operations | iOS caller (file:line) | Web dev constraint |

--- a/middleware.ts
+++ b/middleware.ts
@@ -6,6 +6,13 @@ import { getSupabaseAnonKey, getSupabaseUrl } from '@/lib/supabase/env';
 let loggedConfigError = false;
 
 export async function middleware(req: NextRequest) {
+  if (process.env.NODE_ENV === 'production' && req.nextUrl.hostname === 'www.flyrpro.app') {
+    const canonicalUrl = req.nextUrl.clone();
+    canonicalUrl.protocol = 'https:';
+    canonicalUrl.hostname = 'flyrpro.app';
+    return NextResponse.redirect(canonicalUrl, 301);
+  }
+
   const res = NextResponse.next();
   
   try {


### PR DESCRIPTION
## What this does
Eight UX polish fixes addressing the most user-visible rough edges 
before launch. Covers sidebar stale state, form usability, empty 
states, nav cleanup, and canonical domain enforcement.

## Changes

**Sidebar refresh after creation**
Campaign and farm sidebars now update immediately after creating a 
new campaign or farm. Uses the same custom browser event pattern 
already established for offers (flyr-campaigns-refresh, 
flyr-farms-refresh).

**Add contact form scroll bug**
CreateContactDialog was portaled into the map shell container, 
causing scroll to be clipped by the map's overflow-hidden layout. 
Removed portalContainer prop so the dialog portals to document.body 
like all other modals.

**Address status after contact creation**
Adding a contact from the map location card now triggers 
loadSecondaryData() on the campaign page, refreshing address 
statuses and contacts without a full page reload.

**Empty states**
- Campaign QR tab: distinguishes no addresses vs no QR codes generated
- Campaign Assignments tab: shows "No assignments yet" for managers
- Leads/ContactsHub: distinguishes zero leads from filtered empty results
- Farm contacts tab: improved message with explanation of how contacts 
  are created

**Nav cleanup**
- Removed flyer editor from Create hub (export 501, persistence TODO)
- Removed landing pages create from Create hub (route doesn't exist)
- Removed partner offers from nav (not in launch scope)

**Canonical domain middleware**
Added production-only 301 redirect from www.flyrpro.app to 
flyrpro.app preserving path and search params.

## Verified
- npx tsc --noEmit: 0 errors
- npm run build: 0 errors
- Sidebar refresh: verified manually
- Contact form scroll: verified manually
- Nav audit: all nav items resolve to real pages