### PR TITLE
perf: eliminate redundant API calls, consolidate access state, cache dashboard

### DIFF
--- a/app/(main)/MainLayoutClient.tsx
+++ b/app/(main)/MainLayoutClient.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import { WorkspaceProvider, useWorkspace } from '@/lib/workspace-context';
 import AppTopHeader from '@/components/layout/AppTopHeader';
@@ -255,24 +255,29 @@ export default function MainLayoutClient({
 }: {
   children: React.ReactNode;
 }) {
+  return (
+    <WorkspaceProvider>
+      <MainLayoutContent>{children}</MainLayoutContent>
+    </WorkspaceProvider>
+  );
+}
+
+function MainLayoutContent({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   const pathname = usePathname();
-  const [accessLevel, setAccessLevel] = useState<DashboardAccessLevel | null>(null);
+  const { accessLevel } = useWorkspace();
   const [isAmbassador, setIsAmbassador] = useState(false);
 
   useEffect(() => {
     fetch('/api/access/state', { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
-        if (!data || typeof data.accessLevel !== 'string') {
-          setAccessLevel('unassigned');
-          setIsAmbassador(false);
-          return;
-        }
-        setAccessLevel(data.accessLevel as DashboardAccessLevel);
-        setIsAmbassador(data.isAmbassador === true);
+        setIsAmbassador(data?.isAmbassador === true);
       })
       .catch(() => {
-        setAccessLevel('unassigned');
         setIsAmbassador(false);
       });
   }, []);
@@ -298,14 +303,12 @@ export default function MainLayoutClient({
   })();
 
   return (
-    <WorkspaceProvider>
-      <MainRouteGuard>
-        <MainLayoutNavProvider>
-          <MainLayoutShell tabs={tabs} pathname={pathname} accessLevel={accessLevel}>
-            {children}
-          </MainLayoutShell>
-        </MainLayoutNavProvider>
-      </MainRouteGuard>
-    </WorkspaceProvider>
+    <MainRouteGuard>
+      <MainLayoutNavProvider>
+        <MainLayoutShell tabs={tabs} pathname={pathname} accessLevel={accessLevel}>
+          {children}
+        </MainLayoutShell>
+      </MainLayoutNavProvider>
+    </MainRouteGuard>
   );
 }

--- a/app/api/_utils/workspace.ts
+++ b/app/api/_utils/workspace.ts
@@ -39,6 +39,22 @@ export type WorkspaceMembershipResolution = {
   status?: number;
 };
 
+type PrefetchedMembershipRow = {
+  workspace_id: string;
+  role?: string | null;
+  created_at?: string | null;
+};
+
+type PrefetchedWorkspaceRow = {
+  id: string;
+  max_seats?: number | null;
+};
+
+type ResolveDashboardAccessOptions = {
+  memberships?: PrefetchedMembershipRow[];
+  workspaces?: PrefetchedWorkspaceRow[];
+};
+
 function roleRank(role: string | null | undefined): number {
   if (role === 'owner') return 0;
   if (role === 'admin') return 1;
@@ -62,11 +78,10 @@ function classifyDashboardAccessLevel(
   return 'unassigned';
 }
 
-export async function resolveDashboardAccessLevel(
+async function checkIsFounder(
   supabase: MinimalSupabaseClient,
-  userId: string,
-  requestedWorkspaceId?: string | null
-): Promise<DashboardAccessResolution> {
+  userId: string
+): Promise<boolean> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const supabaseAny = supabase as any;
 
@@ -76,9 +91,28 @@ export async function resolveDashboardAccessLevel(
     .eq('user_id', userId)
     .eq('is_founder', true)
     .maybeSingle();
-  const isFounder = !!founderProfile?.user_id;
 
-  const resolution = await resolveWorkspaceIdForUser(supabase, userId, requestedWorkspaceId);
+  return !!founderProfile?.user_id;
+}
+
+export async function resolveDashboardAccessLevel(
+  supabase: MinimalSupabaseClient,
+  userId: string,
+  requestedWorkspaceId?: string | null,
+  options: ResolveDashboardAccessOptions = {}
+): Promise<DashboardAccessResolution> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const supabaseAny = supabase as any;
+
+  const [isFounder, resolution] = await Promise.all([
+    checkIsFounder(supabase, userId),
+    resolveWorkspaceIdForUser(
+      supabase,
+      userId,
+      requestedWorkspaceId,
+      options.memberships
+    ),
+  ]);
   if (!resolution.workspaceId) {
     if (isFounder) {
       return {
@@ -101,24 +135,40 @@ export async function resolveDashboardAccessLevel(
     };
   }
 
-  const { data: membership } = await supabaseAny
-    .from('workspace_members')
-    .select('role')
-    .eq('user_id', userId)
-    .eq('workspace_id', resolution.workspaceId)
-    .maybeSingle();
-  const role = (membership?.role as WorkspaceRole) ?? null;
+  const prefetchedMembership = options.memberships?.find(
+    (row) => row.workspace_id === resolution.workspaceId
+  );
+  const prefetchedWorkspace = options.workspaces?.find(
+    (row) => row.id === resolution.workspaceId
+  );
 
-  const { data: memberRows } = await supabaseAny
-    .from('workspace_members')
-    .select('user_id')
-    .eq('workspace_id', resolution.workspaceId);
+  const [membershipResult, memberRowsResult, workspaceResult] = await Promise.all([
+    prefetchedMembership
+      ? Promise.resolve({ data: { role: prefetchedMembership.role ?? null } })
+      : supabaseAny
+          .from('workspace_members')
+          .select('role')
+          .eq('user_id', userId)
+          .eq('workspace_id', resolution.workspaceId)
+          .maybeSingle(),
+    supabaseAny
+      .from('workspace_members')
+      .select('user_id')
+      .eq('workspace_id', resolution.workspaceId),
+    prefetchedWorkspace
+      ? Promise.resolve({ data: { max_seats: prefetchedWorkspace.max_seats ?? null } })
+      : supabaseAny
+          .from('workspaces')
+          .select('max_seats')
+          .eq('id', resolution.workspaceId)
+          .maybeSingle(),
+  ]);
+
+  const membership = membershipResult.data;
+  const role = (membership?.role as WorkspaceRole) ?? null;
+  const memberRows = memberRowsResult.data;
   const memberCount = Array.isArray(memberRows) ? memberRows.length : 0;
-  const { data: workspace } = await supabaseAny
-    .from('workspaces')
-    .select('max_seats')
-    .eq('id', resolution.workspaceId)
-    .maybeSingle();
+  const workspace = workspaceResult.data;
   const maxSeats =
     typeof workspace?.max_seats === 'number' ? workspace.max_seats : null;
 
@@ -221,12 +271,24 @@ export async function resolveWorkspaceMembershipForUser(
 export async function resolveWorkspaceIdForUser(
   supabase: MinimalSupabaseClient,
   userId: string,
-  requestedWorkspaceId?: string | null
+  requestedWorkspaceId?: string | null,
+  prefetchedMemberships?: PrefetchedMembershipRow[]
 ): Promise<{ workspaceId: string | null; error?: string; status?: number }> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const supabaseAny = supabase as any;
 
   if (requestedWorkspaceId) {
+    if (prefetchedMemberships) {
+      const membership = prefetchedMemberships.find(
+        (row) => row.workspace_id === requestedWorkspaceId
+      );
+      if (!membership?.workspace_id) {
+        return { workspaceId: null, error: 'You are not a member of the selected workspace', status: 403 };
+      }
+
+      return { workspaceId: membership.workspace_id };
+    }
+
     const { data: membership, error } = await supabaseAny
       .from('workspace_members')
       .select('workspace_id')
@@ -252,31 +314,43 @@ export async function resolveWorkspaceIdForUser(
       ? preferredProfile.current_workspace_id
       : null;
   if (preferredWorkspaceId) {
-    const { data: preferredMembership } = await supabaseAny
-      .from('workspace_members')
-      .select('workspace_id')
-      .eq('user_id', userId)
-      .eq('workspace_id', preferredWorkspaceId)
-      .maybeSingle();
+    if (prefetchedMemberships) {
+      const preferredMembership = prefetchedMemberships.find(
+        (row) => row.workspace_id === preferredWorkspaceId
+      );
 
-    if (preferredMembership?.workspace_id) {
-      return { workspaceId: preferredMembership.workspace_id };
+      if (preferredMembership?.workspace_id) {
+        return { workspaceId: preferredMembership.workspace_id };
+      }
+    } else {
+      const { data: preferredMembership } = await supabaseAny
+        .from('workspace_members')
+        .select('workspace_id')
+        .eq('user_id', userId)
+        .eq('workspace_id', preferredWorkspaceId)
+        .maybeSingle();
+
+      if (preferredMembership?.workspace_id) {
+        return { workspaceId: preferredMembership.workspace_id };
+      }
     }
   }
 
-  const { data: fallbackMembership, error: fallbackError } = await supabaseAny
-    .from('workspace_members')
-    .select('workspace_id, role, created_at')
-    .eq('user_id', userId)
-    .order('created_at', { ascending: true });
+  const fallbackResult = prefetchedMemberships
+    ? { data: prefetchedMemberships, error: null }
+    : await supabaseAny
+        .from('workspace_members')
+        .select('workspace_id, role, created_at')
+        .eq('user_id', userId)
+        .order('created_at', { ascending: true });
 
-  const memberships = (fallbackMembership ?? []) as Array<{
+  const memberships = (fallbackResult.data ?? []) as Array<{
     workspace_id: string;
     role?: string | null;
     created_at?: string | null;
   }>;
 
-  if (fallbackError || memberships.length === 0) {
+  if (fallbackResult.error || memberships.length === 0) {
     return { workspaceId: null, error: 'No workspace membership found for this user', status: 400 };
   }
 

--- a/app/api/_utils/workspace.ts
+++ b/app/api/_utils/workspace.ts
@@ -53,6 +53,13 @@ type PrefetchedWorkspaceRow = {
 type ResolveDashboardAccessOptions = {
   memberships?: PrefetchedMembershipRow[];
   workspaces?: PrefetchedWorkspaceRow[];
+  userProfile?: UserProfileAccessRow | null;
+};
+
+type UserProfileAccessRow = {
+  user_id?: string | null;
+  current_workspace_id?: string | null;
+  is_founder?: boolean | null;
 };
 
 function roleRank(role: string | null | undefined): number {
@@ -78,21 +85,20 @@ function classifyDashboardAccessLevel(
   return 'unassigned';
 }
 
-async function checkIsFounder(
+async function getUserProfileAccess(
   supabase: MinimalSupabaseClient,
   userId: string
-): Promise<boolean> {
+): Promise<UserProfileAccessRow | null> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const supabaseAny = supabase as any;
 
-  const { data: founderProfile } = await supabaseAny
+  const { data: profile } = await supabaseAny
     .from('user_profiles')
-    .select('user_id')
+    .select('user_id, current_workspace_id, is_founder')
     .eq('user_id', userId)
-    .eq('is_founder', true)
     .maybeSingle();
 
-  return !!founderProfile?.user_id;
+  return profile ?? null;
 }
 
 export async function resolveDashboardAccessLevel(
@@ -104,15 +110,20 @@ export async function resolveDashboardAccessLevel(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const supabaseAny = supabase as any;
 
-  const [isFounder, resolution] = await Promise.all([
-    checkIsFounder(supabase, userId),
+  const profilePromise = options.userProfile
+    ? Promise.resolve(options.userProfile)
+    : getUserProfileAccess(supabase, userId);
+  const [profile, resolution] = await Promise.all([
+    profilePromise,
     resolveWorkspaceIdForUser(
       supabase,
       userId,
       requestedWorkspaceId,
-      options.memberships
+      options.memberships,
+      profilePromise
     ),
   ]);
+  const isFounder = profile?.is_founder === true;
   if (!resolution.workspaceId) {
     if (isFounder) {
       return {
@@ -272,7 +283,8 @@ export async function resolveWorkspaceIdForUser(
   supabase: MinimalSupabaseClient,
   userId: string,
   requestedWorkspaceId?: string | null,
-  prefetchedMemberships?: PrefetchedMembershipRow[]
+  prefetchedMemberships?: PrefetchedMembershipRow[],
+  prefetchedProfile?: UserProfileAccessRow | null | Promise<UserProfileAccessRow | null>
 ): Promise<{ workspaceId: string | null; error?: string; status?: number }> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const supabaseAny = supabase as any;
@@ -303,11 +315,13 @@ export async function resolveWorkspaceIdForUser(
     return { workspaceId: membership.workspace_id };
   }
 
-  const { data: preferredProfile } = await supabaseAny
-    .from('user_profiles')
-    .select('current_workspace_id')
-    .eq('user_id', userId)
-    .maybeSingle();
+  const preferredProfile = prefetchedProfile !== undefined
+    ? await prefetchedProfile
+    : (await supabaseAny
+        .from('user_profiles')
+        .select('user_id, current_workspace_id, is_founder')
+        .eq('user_id', userId)
+        .maybeSingle()).data;
 
   const preferredWorkspaceId =
     typeof preferredProfile?.current_workspace_id === 'string'

--- a/app/api/access/state/route.ts
+++ b/app/api/access/state/route.ts
@@ -75,6 +75,7 @@ export async function GET(request: NextRequest) {
         isSalesperson,
         salesperson: salespersonLookup.data ?? null,
         accessLevel: isSalesperson ? 'salesperson' : access.level,
+        onboardingComplete: false,
         memberCount: access.memberCount,
         workspaces: workspaceOptions,
       });
@@ -82,7 +83,7 @@ export async function GET(request: NextRequest) {
 
     const { data: workspace } = await admin
       .from('workspaces')
-      .select('id, name, industry, subscription_status, trial_ends_at, max_seats')
+      .select('id, name, industry, subscription_status, trial_ends_at, max_seats, onboarding_completed_at')
       .eq('id', access.workspaceId)
       .single();
 
@@ -101,6 +102,7 @@ export async function GET(request: NextRequest) {
         plan: isAmbassador ? 'ambassador' : 'free',
         planBadgeLabel: isAmbassador ? 'AMBASSADOR' : null,
         accessLevel: access.level,
+        onboardingComplete: false,
         memberCount: access.memberCount,
         workspaces: workspaceOptions,
       });
@@ -153,6 +155,7 @@ export async function GET(request: NextRequest) {
       isSalesperson,
       salesperson: salespersonLookup.data ?? null,
       accessLevel: isSalesperson && !access.isFounder ? 'salesperson' : access.level,
+      onboardingComplete: !!workspace.onboarding_completed_at,
       memberCount: access.memberCount,
       workspaces: workspaceOptions,
       reason:

--- a/app/api/access/state/route.ts
+++ b/app/api/access/state/route.ts
@@ -18,30 +18,33 @@ export async function GET(request: NextRequest) {
 
     const admin = createAdminClient();
     const normalizedEmail = requestUser.email?.trim().toLowerCase() ?? null;
-    const approvedAmbassador = await getApprovedAmbassadorByEmail(admin, normalizedEmail);
+    const [approvedAmbassador, salespersonLookup, membershipResult] = await Promise.all([
+      getApprovedAmbassadorByEmail(admin, normalizedEmail),
+      normalizedEmail
+        ? admin
+            .from('salespeople')
+            .select('id, full_name, email, status')
+            .eq('email', normalizedEmail)
+            .eq('status', 'active')
+            .maybeSingle()
+        : Promise.resolve({ data: null, error: null }),
+      admin
+        .from('workspace_members')
+        .select('workspace_id, role, created_at')
+        .eq('user_id', requestUser.id)
+        .order('created_at', { ascending: true }),
+    ]);
     const isAmbassador = !!approvedAmbassador;
-    const salespersonLookup = normalizedEmail
-      ? await admin
-          .from('salespeople')
-          .select('id, full_name, email, status')
-          .eq('email', normalizedEmail)
-          .eq('status', 'active')
-          .maybeSingle()
-      : { data: null, error: null };
     const isSalesperson = !!salespersonLookup.data && !salespersonLookup.error;
     const requestedWorkspaceId = request.nextUrl.searchParams.get('workspaceId')?.trim() || null;
-    const { data: membershipRows } = await admin
-      .from('workspace_members')
-      .select('workspace_id, role, created_at')
-      .eq('user_id', requestUser.id)
-      .order('created_at', { ascending: true });
+    const membershipRows = membershipResult.data ?? [];
     const workspaceIds = Array.from(
       new Set((membershipRows ?? []).map((row) => row.workspace_id).filter(Boolean))
     );
     const { data: workspaceRows } = workspaceIds.length
       ? await admin
           .from('workspaces')
-          .select('id, name, industry')
+          .select('id, name, industry, subscription_status, trial_ends_at, max_seats, onboarding_completed_at')
           .in('id', workspaceIds)
       : { data: [] };
     const workspaceOptions = (workspaceRows ?? []).map((workspace) => {
@@ -56,7 +59,11 @@ export async function GET(request: NextRequest) {
     const access = await resolveDashboardAccessLevel(
       admin as unknown as MinimalSupabaseClient,
       requestUser.id,
-      requestedWorkspaceId
+      requestedWorkspaceId,
+      {
+        memberships: membershipRows,
+        workspaces: workspaceRows ?? [],
+      }
     );
     if (!access.workspaceId) {
       return NextResponse.json({
@@ -81,11 +88,7 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    const { data: workspace } = await admin
-      .from('workspaces')
-      .select('id, name, industry, subscription_status, trial_ends_at, max_seats, onboarding_completed_at')
-      .eq('id', access.workspaceId)
-      .single();
+    const workspace = (workspaceRows ?? []).find((row) => row.id === access.workspaceId) ?? null;
 
     if (!workspace) {
       return NextResponse.json({

--- a/app/api/home/dashboard/route.ts
+++ b/app/api/home/dashboard/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server';
-import { unstable_cache } from 'next/cache';
 import { getSupabaseServerClient, createAdminClient } from '@/lib/supabase/server';
 import { resolveWorkspaceIdForUser, type MinimalSupabaseClient } from '@/app/api/_utils/workspace';
 
@@ -34,32 +33,6 @@ type ContactMetricRow = {
   appointment_at?: string | null;
   created_at: string | null;
   updated_at: string | null;
-};
-
-type DashboardPayload = {
-  user: { firstName: string; fullName: string };
-  stats: {
-    doorsAllTime: number;
-    conversationsAllTime: number;
-    totalMinutesAllTime: number;
-    doorsThisWeek: number;
-    minutesThisWeek: number;
-    sessionsThisWeek: number;
-    dayStreak: number;
-  };
-  weeklyGoals: {
-    doors: number;
-    sessions?: number;
-    minutes?: number;
-  };
-  recentCampaigns: { id: string; name: string }[];
-  lastSessionAt: string | null;
-  metrics: {
-    doors: number;
-    convos: number;
-    leads: number;
-    appointments: number;
-  };
 };
 
 function isMissingRelation(error: unknown, relation: string): boolean {
@@ -234,16 +207,6 @@ export async function GET(request: Request) {
       );
     }
     const targetWorkspaceId = workspaceResolution.workspaceId;
-    const { data: membershipData } = await supabase
-      .from('workspace_members')
-      .select('role')
-      .eq('workspace_id', targetWorkspaceId)
-      .eq('user_id', userId)
-      .maybeSingle();
-
-    const membership = (membershipData ?? null) as WorkspaceMembershipRow | null;
-    const getCachedDashboard = unstable_cache(
-      async (): Promise<DashboardPayload> => {
     const startOfWeek = getStartOfWeekUTC();
 
     // Run independent fetches in parallel
@@ -317,6 +280,15 @@ export async function GET(request: Request) {
     let weeklyDoorGoal = profile?.weekly_door_goal ?? 100;
     let weeklySessionsGoal = profile?.weekly_sessions_goal ?? undefined;
     let weeklyMinutesGoal = profile?.weekly_minutes_goal ?? undefined;
+
+    const { data: membershipData } = await supabase
+      .from('workspace_members')
+      .select('role')
+      .eq('workspace_id', targetWorkspaceId)
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    const membership = (membershipData ?? null) as WorkspaceMembershipRow | null;
 
     if (membership?.role === 'member') {
       const [{ data: workspaceGoalsData }, { data: workspaceMembersData }] = await Promise.all([
@@ -428,7 +400,7 @@ export async function GET(request: Request) {
       metricAppointments = contactSummary.appointments;
     }
 
-    const body: DashboardPayload = {
+    const body = {
       user: { firstName, fullName },
       stats: {
         doorsAllTime,
@@ -454,13 +426,6 @@ export async function GET(request: Request) {
       },
     };
 
-    return body;
-      },
-      ['home-dashboard', userId, targetWorkspaceId],
-      { revalidate: 30 }
-    );
-
-    const body = await getCachedDashboard();
     return NextResponse.json(body);
   } catch (err) {
     console.error('Home dashboard error:', err);

--- a/app/api/home/dashboard/route.ts
+++ b/app/api/home/dashboard/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { unstable_cache } from 'next/cache';
 import { getSupabaseServerClient, createAdminClient } from '@/lib/supabase/server';
 import { resolveWorkspaceIdForUser, type MinimalSupabaseClient } from '@/app/api/_utils/workspace';
 
@@ -33,6 +34,32 @@ type ContactMetricRow = {
   appointment_at?: string | null;
   created_at: string | null;
   updated_at: string | null;
+};
+
+type DashboardPayload = {
+  user: { firstName: string; fullName: string };
+  stats: {
+    doorsAllTime: number;
+    conversationsAllTime: number;
+    totalMinutesAllTime: number;
+    doorsThisWeek: number;
+    minutesThisWeek: number;
+    sessionsThisWeek: number;
+    dayStreak: number;
+  };
+  weeklyGoals: {
+    doors: number;
+    sessions?: number;
+    minutes?: number;
+  };
+  recentCampaigns: { id: string; name: string }[];
+  lastSessionAt: string | null;
+  metrics: {
+    doors: number;
+    convos: number;
+    leads: number;
+    appointments: number;
+  };
 };
 
 function isMissingRelation(error: unknown, relation: string): boolean {
@@ -207,6 +234,16 @@ export async function GET(request: Request) {
       );
     }
     const targetWorkspaceId = workspaceResolution.workspaceId;
+    const { data: membershipData } = await supabase
+      .from('workspace_members')
+      .select('role')
+      .eq('workspace_id', targetWorkspaceId)
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    const membership = (membershipData ?? null) as WorkspaceMembershipRow | null;
+    const getCachedDashboard = unstable_cache(
+      async (): Promise<DashboardPayload> => {
     const startOfWeek = getStartOfWeekUTC();
 
     // Run independent fetches in parallel
@@ -280,15 +317,6 @@ export async function GET(request: Request) {
     let weeklyDoorGoal = profile?.weekly_door_goal ?? 100;
     let weeklySessionsGoal = profile?.weekly_sessions_goal ?? undefined;
     let weeklyMinutesGoal = profile?.weekly_minutes_goal ?? undefined;
-
-    const { data: membershipData } = await supabase
-      .from('workspace_members')
-      .select('role')
-      .eq('workspace_id', targetWorkspaceId)
-      .eq('user_id', userId)
-      .maybeSingle();
-
-    const membership = (membershipData ?? null) as WorkspaceMembershipRow | null;
 
     if (membership?.role === 'member') {
       const [{ data: workspaceGoalsData }, { data: workspaceMembersData }] = await Promise.all([
@@ -400,7 +428,7 @@ export async function GET(request: Request) {
       metricAppointments = contactSummary.appointments;
     }
 
-    const body = {
+    const body: DashboardPayload = {
       user: { firstName, fullName },
       stats: {
         doorsAllTime,
@@ -426,6 +454,13 @@ export async function GET(request: Request) {
       },
     };
 
+    return body;
+      },
+      ['home-dashboard', userId, targetWorkspaceId],
+      { revalidate: 30 }
+    );
+
+    const body = await getCachedDashboard();
     return NextResponse.json(body);
   } catch (err) {
     console.error('Home dashboard error:', err);

--- a/components/guard/MainRouteGuard.tsx
+++ b/components/guard/MainRouteGuard.tsx
@@ -3,12 +3,7 @@
 import { useEffect, useState, type ReactNode } from 'react';
 import { useRouter } from 'next/navigation';
 import { PaywallOverlay } from './PaywallOverlay';
-
-const REDIRECT_PATHS = ['/login', '/onboarding'];
-function shouldRedirect(path: string): boolean {
-  if (REDIRECT_PATHS.includes(path)) return true;
-  return false;
-}
+import { useWorkspace } from '@/lib/workspace-context';
 
 function isSubscribe(path: string): boolean {
   return path === '/subscribe' || path.startsWith('/subscribe');
@@ -17,54 +12,19 @@ function isSubscribe(path: string): boolean {
 export function MainRouteGuard({ children }: { children: ReactNode }) {
   const router = useRouter();
   const [mounted, setMounted] = useState(false);
-  const [allowed, setAllowed] = useState(false);
-  const [showPaywallOverlay, setShowPaywallOverlay] = useState(false);
-  const [checking, setChecking] = useState(true);
+  const { isLoading, redirectPath } = useWorkspace();
+  const showPaywallOverlay = !!redirectPath && isSubscribe(redirectPath);
 
   useEffect(() => {
     setMounted(true);
   }, []);
 
   useEffect(() => {
-    if (!mounted) return;
-    let cancelled = false;
-    fetch('/api/access/redirect', { credentials: 'include' })
-      .then((res) => {
-        if (!cancelled) {
-          if (res.status === 401) {
-            setAllowed(false);
-            router.replace('/login');
-            setChecking(false);
-            return;
-          }
-          return res.json();
-        }
-      })
-      .then((data) => {
-        if (cancelled || !data) return;
-        const path = (data.path as string) ?? '/home';
-        if (shouldRedirect(path)) {
-          router.replace(path);
-          setAllowed(false);
-        } else if (isSubscribe(path)) {
-          setAllowed(true);
-          setShowPaywallOverlay(true);
-        } else {
-          setAllowed(true);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) setAllowed(true);
-      })
-      .finally(() => {
-        if (!cancelled) setChecking(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [mounted, router]);
+    if (!mounted || isLoading || !redirectPath || isSubscribe(redirectPath)) return;
+    router.replace(redirectPath);
+  }, [isLoading, mounted, redirectPath, router]);
 
-  if (!mounted || checking) {
+  if (!mounted || isLoading) {
     return (
       <div className="flex h-screen flex-col items-center justify-center bg-gray-50 dark:bg-background">
         <p className="text-muted-foreground">Loading…</p>
@@ -72,7 +32,7 @@ export function MainRouteGuard({ children }: { children: ReactNode }) {
     );
   }
 
-  if (!allowed) {
+  if (redirectPath && !showPaywallOverlay) {
     return null;
   }
 

--- a/components/home/HomeDashboardView.tsx
+++ b/components/home/HomeDashboardView.tsx
@@ -47,7 +47,8 @@ type HomeDashboardViewProps = {
   disableGoalEditing?: boolean;
 };
 
-const fetchedWorkspaceIds = new Set<string>();
+const dashboardCache = new Map<string, { data: HomeDashboardData; fetchedAt: number }>();
+const CACHE_TTL_MS = 30_000;
 
 export function HomeDashboardView({ disableGoalEditing = false }: HomeDashboardViewProps) {
   const { currentWorkspace, currentWorkspaceId } = useWorkspace();
@@ -58,16 +59,22 @@ export function HomeDashboardView({ disableGoalEditing = false }: HomeDashboardV
 
   const load = useCallback(async () => {
     if (!currentWorkspaceId) return;
-    if (fetchedWorkspaceIds.has(currentWorkspaceId)) return;
+
+    const cacheKey = currentWorkspaceId;
+    const cached = dashboardCache.get(cacheKey);
+    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+      setData(cached.data);
+      setLoading(false);
+      return;
+    }
 
     setLoading(true);
     setError(null);
-    fetchedWorkspaceIds.add(currentWorkspaceId);
     try {
       const res = await fetchHomeDashboard(currentWorkspaceId);
+      dashboardCache.set(cacheKey, { data: res, fetchedAt: Date.now() });
       setData(res);
     } catch (e) {
-      fetchedWorkspaceIds.delete(currentWorkspaceId);
       setError(e instanceof Error ? e.message : 'Failed to load');
     } finally {
       setLoading(false);

--- a/components/home/HomeDashboardView.tsx
+++ b/components/home/HomeDashboardView.tsx
@@ -62,11 +62,12 @@ export function HomeDashboardView({ disableGoalEditing = false }: HomeDashboardV
 
     setLoading(true);
     setError(null);
+    fetchedWorkspaceIds.add(currentWorkspaceId);
     try {
       const res = await fetchHomeDashboard(currentWorkspaceId);
-      fetchedWorkspaceIds.add(currentWorkspaceId);
       setData(res);
     } catch (e) {
+      fetchedWorkspaceIds.delete(currentWorkspaceId);
       setError(e instanceof Error ? e.message : 'Failed to load');
     } finally {
       setLoading(false);

--- a/components/home/HomeDashboardView.tsx
+++ b/components/home/HomeDashboardView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { fetchHomeDashboard, type HomeDashboardData } from '@/lib/home-dashboard';
 import { HomeHeaderRow } from './HomeHeaderRow';
 import { WeeklyGoalsCard } from './WeeklyGoalsCard';
@@ -47,23 +47,24 @@ type HomeDashboardViewProps = {
   disableGoalEditing?: boolean;
 };
 
+const fetchedWorkspaceIds = new Set<string>();
+
 export function HomeDashboardView({ disableGoalEditing = false }: HomeDashboardViewProps) {
   const { currentWorkspace, currentWorkspaceId } = useWorkspace();
   const copy = getIndustryCopy(currentWorkspace?.industry);
   const [data, setData] = useState<HomeDashboardData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const loadedWorkspaceIdRef = useRef<string | null>(null);
 
   const load = useCallback(async () => {
     if (!currentWorkspaceId) return;
-    if (loadedWorkspaceIdRef.current === currentWorkspaceId) return;
+    if (fetchedWorkspaceIds.has(currentWorkspaceId)) return;
 
     setLoading(true);
     setError(null);
     try {
       const res = await fetchHomeDashboard(currentWorkspaceId);
-      loadedWorkspaceIdRef.current = currentWorkspaceId;
+      fetchedWorkspaceIds.add(currentWorkspaceId);
       setData(res);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load');

--- a/components/home/HomeDashboardView.tsx
+++ b/components/home/HomeDashboardView.tsx
@@ -48,6 +48,7 @@ type HomeDashboardViewProps = {
 };
 
 const dashboardCache = new Map<string, { data: HomeDashboardData; fetchedAt: number }>();
+const inFlightWorkspaceIds = new Set<string>();
 const CACHE_TTL_MS = 30_000;
 
 export function HomeDashboardView({ disableGoalEditing = false }: HomeDashboardViewProps) {
@@ -68,6 +69,9 @@ export function HomeDashboardView({ disableGoalEditing = false }: HomeDashboardV
       return;
     }
 
+    if (inFlightWorkspaceIds.has(currentWorkspaceId)) return;
+    inFlightWorkspaceIds.add(currentWorkspaceId);
+
     setLoading(true);
     setError(null);
     try {
@@ -77,6 +81,7 @@ export function HomeDashboardView({ disableGoalEditing = false }: HomeDashboardV
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load');
     } finally {
+      inFlightWorkspaceIds.delete(currentWorkspaceId);
       setLoading(false);
     }
   }, [currentWorkspaceId]);

--- a/components/home/HomeDashboardView.tsx
+++ b/components/home/HomeDashboardView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { fetchHomeDashboard, type HomeDashboardData } from '@/lib/home-dashboard';
 import { HomeHeaderRow } from './HomeHeaderRow';
 import { WeeklyGoalsCard } from './WeeklyGoalsCard';
@@ -53,12 +53,17 @@ export function HomeDashboardView({ disableGoalEditing = false }: HomeDashboardV
   const [data, setData] = useState<HomeDashboardData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const loadedWorkspaceIdRef = useRef<string | null>(null);
 
   const load = useCallback(async () => {
+    if (!currentWorkspaceId) return;
+    if (loadedWorkspaceIdRef.current === currentWorkspaceId) return;
+
     setLoading(true);
     setError(null);
     try {
       const res = await fetchHomeDashboard(currentWorkspaceId);
+      loadedWorkspaceIdRef.current = currentWorkspaceId;
       setData(res);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load');

--- a/components/home/MyCampaignAssignmentsCard.tsx
+++ b/components/home/MyCampaignAssignmentsCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { Target } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -31,6 +31,7 @@ export function MyCampaignAssignmentsCard() {
   const [assignments, setAssignments] = useState<AssignmentRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [message, setMessage] = useState<string | null>(null);
+  const loadedWorkspaceIdRef = useRef<string | null>(null);
 
   const loadAssignments = useCallback(async () => {
     if (!currentWorkspaceId) {
@@ -38,6 +39,7 @@ export function MyCampaignAssignmentsCard() {
       setLoading(false);
       return;
     }
+    if (loadedWorkspaceIdRef.current === currentWorkspaceId) return;
 
     setLoading(true);
     try {
@@ -53,6 +55,7 @@ export function MyCampaignAssignmentsCard() {
         setAssignments([]);
         return;
       }
+      loadedWorkspaceIdRef.current = currentWorkspaceId;
       setAssignments(Array.isArray(payload?.assignments) ? payload.assignments : []);
     } catch {
       setMessage('Failed to load campaign assignments.');

--- a/components/home/MyCampaignAssignmentsCard.tsx
+++ b/components/home/MyCampaignAssignmentsCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Target } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -26,12 +26,13 @@ function modeLabel(mode: CampaignAssignmentMode): string {
   return mode === 'zone_split' ? 'Zone' : 'Whole team';
 }
 
+const fetchedWorkspaceIds = new Set<string>();
+
 export function MyCampaignAssignmentsCard() {
   const { currentWorkspaceId } = useWorkspace();
   const [assignments, setAssignments] = useState<AssignmentRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [message, setMessage] = useState<string | null>(null);
-  const loadedWorkspaceIdRef = useRef<string | null>(null);
 
   const loadAssignments = useCallback(async () => {
     if (!currentWorkspaceId) {
@@ -39,7 +40,7 @@ export function MyCampaignAssignmentsCard() {
       setLoading(false);
       return;
     }
-    if (loadedWorkspaceIdRef.current === currentWorkspaceId) return;
+    if (fetchedWorkspaceIds.has(currentWorkspaceId)) return;
 
     setLoading(true);
     try {
@@ -55,7 +56,7 @@ export function MyCampaignAssignmentsCard() {
         setAssignments([]);
         return;
       }
-      loadedWorkspaceIdRef.current = currentWorkspaceId;
+      fetchedWorkspaceIds.add(currentWorkspaceId);
       setAssignments(Array.isArray(payload?.assignments) ? payload.assignments : []);
     } catch {
       setMessage('Failed to load campaign assignments.');

--- a/components/home/MyCampaignAssignmentsCard.tsx
+++ b/components/home/MyCampaignAssignmentsCard.tsx
@@ -43,6 +43,7 @@ export function MyCampaignAssignmentsCard() {
     if (fetchedWorkspaceIds.has(currentWorkspaceId)) return;
 
     setLoading(true);
+    fetchedWorkspaceIds.add(currentWorkspaceId);
     try {
       const response = await fetch(
         `/api/campaign-assignments?workspaceId=${encodeURIComponent(currentWorkspaceId)}`,
@@ -52,13 +53,14 @@ export function MyCampaignAssignmentsCard() {
         | { assignments?: AssignmentRow[]; error?: string }
         | null;
       if (!response.ok) {
+        fetchedWorkspaceIds.delete(currentWorkspaceId);
         setMessage(payload?.error ?? 'Failed to load campaign assignments.');
         setAssignments([]);
         return;
       }
-      fetchedWorkspaceIds.add(currentWorkspaceId);
       setAssignments(Array.isArray(payload?.assignments) ? payload.assignments : []);
     } catch {
+      fetchedWorkspaceIds.delete(currentWorkspaceId);
       setMessage('Failed to load campaign assignments.');
       setAssignments([]);
     } finally {

--- a/components/layout/AppTopHeader.tsx
+++ b/components/layout/AppTopHeader.tsx
@@ -28,11 +28,6 @@ type UserProfileLite = {
   countryCode: string | null;
 };
 
-type AccessStatePayload = {
-  isFounder?: boolean;
-  planBadgeLabel?: string | null;
-};
-
 function initialsFromName(nameOrEmail: string | null): string {
   const value = (nameOrEmail ?? '').trim();
   if (!value) return 'U';
@@ -44,7 +39,13 @@ function initialsFromName(nameOrEmail: string | null): string {
 export default function AppTopHeader() {
   const { theme, toggleTheme } = useTheme();
   const { isFullscreen, toggle: toggleFullscreen } = useFullscreen();
-  const { currentWorkspace, membershipsByWorkspaceId, refreshWorkspaces } = useWorkspace();
+  const {
+    currentWorkspace,
+    membershipsByWorkspaceId,
+    refreshWorkspaces,
+    isFounder,
+    planBadgeLabel,
+  } = useWorkspace();
   const [profile, setProfile] = useState<UserProfileLite>({
     email: null,
     fullName: null,
@@ -56,30 +57,8 @@ export default function AppTopHeader() {
   const [feedbackError, setFeedbackError] = useState<string | null>(null);
   const [feedbackSuccess, setFeedbackSuccess] = useState<string | null>(null);
   const [feedbackSubmitting, setFeedbackSubmitting] = useState(false);
-  const [isFounder, setIsFounder] = useState<boolean>(false);
-  const [planBadgeLabel, setPlanBadgeLabel] = useState<string | null>(null);
   const [profileEditOpen, setProfileEditOpen] = useState(false);
   const mainLayoutNav = useMainLayoutNav();
-
-  useEffect(() => {
-    let mounted = true;
-    fetch('/api/access/state', { credentials: 'include' })
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        if (!mounted || !data) return;
-        const payload = data as AccessStatePayload;
-        if (typeof payload.isFounder === 'boolean') {
-          setIsFounder(payload.isFounder);
-        }
-        if (typeof payload.planBadgeLabel === 'string') {
-          setPlanBadgeLabel(payload.planBadgeLabel);
-        } else {
-          setPlanBadgeLabel(null);
-        }
-      })
-      .catch(() => {});
-    return () => { mounted = false; };
-  }, []);
 
   const refreshProfile = useCallback(() => {
     getClientAsync()

--- a/lib/workspace-context.tsx
+++ b/lib/workspace-context.tsx
@@ -6,6 +6,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from 'react';
@@ -101,6 +102,8 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
   const [planBadgeLabel, setPlanBadgeLabel] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const initialLoadDoneRef = useRef(false);
+  const currentAuthUserIdRef = useRef<string | null>(null);
 
   const refreshWorkspaces = useCallback(async () => {
     setIsLoading(true);
@@ -140,6 +143,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
             : 'member';
         const userId = typeof data.userId === 'string' && data.userId ? data.userId : null;
 
+        currentAuthUserIdRef.current = userId;
         setCurrentUserId(userId);
         setWorkspaces([
           {
@@ -184,11 +188,13 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
         setWorkspaces([]);
         setMemberships([]);
         setMemberCountByWorkspaceId({});
+        currentAuthUserIdRef.current = null;
         setCurrentUserId(null);
         setCurrentWorkspaceIdState(null);
         setIsLoading(false);
         return;
       }
+      currentAuthUserIdRef.current = user.id;
       setCurrentUserId(user.id);
 
       const { data: membershipRows, error: membershipError } = await supabase
@@ -315,6 +321,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
                 ? data.role
                 : 'member';
             const userId = typeof data.userId === 'string' && data.userId ? data.userId : null;
+            currentAuthUserIdRef.current = userId;
             setCurrentUserId(userId);
             setWorkspaces([
               {
@@ -349,6 +356,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
       setWorkspaces([]);
       setMemberships([]);
       setMemberCountByWorkspaceId({});
+      currentAuthUserIdRef.current = null;
       setCurrentUserId(null);
       setCurrentWorkspaceIdState(null);
     } finally {
@@ -380,7 +388,9 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
   }, [currentUserId, refreshWorkspaces]);
 
   useEffect(() => {
-    refreshWorkspaces();
+    void refreshWorkspaces().finally(() => {
+      initialLoadDoneRef.current = true;
+    });
   }, [refreshWorkspaces]);
 
   useEffect(() => {
@@ -391,8 +401,23 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
       .then((supabase) => {
         const {
           data: { subscription },
-        } = supabase.auth.onAuthStateChange(() => {
-          if (!isCancelled) void refreshWorkspaces();
+        } = supabase.auth.onAuthStateChange((event, session) => {
+          if (isCancelled || event === 'INITIAL_SESSION' || !initialLoadDoneRef.current) {
+            return;
+          }
+
+          const nextUserId = session?.user?.id ?? null;
+          if (event === 'SIGNED_OUT') {
+            if (currentAuthUserIdRef.current === null) return;
+            currentAuthUserIdRef.current = null;
+            void refreshWorkspaces();
+            return;
+          }
+
+          if ((event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') && nextUserId !== currentAuthUserIdRef.current) {
+            currentAuthUserIdRef.current = nextUserId;
+            void refreshWorkspaces();
+          }
         });
         unsubscribe = () => subscription.unsubscribe();
       })

--- a/lib/workspace-context.tsx
+++ b/lib/workspace-context.tsx
@@ -10,6 +10,7 @@ import {
   type ReactNode,
 } from 'react';
 import { getClientAsync } from '@/lib/supabase/client';
+import type { DashboardAccessLevel } from '@/app/api/_utils/workspace';
 
 const CURRENT_WORKSPACE_STORAGE_KEY = 'flyr.currentWorkspaceId';
 function workspaceStorageKeyForUser(userId: string): string {
@@ -44,6 +45,9 @@ type WorkspaceContextValue = {
   memberCountByWorkspaceId: Record<string, number>;
   currentWorkspace: Workspace | null;
   currentWorkspaceId: string | null;
+  accessLevel: DashboardAccessLevel | null;
+  isFounder: boolean;
+  planBadgeLabel: string | null;
   isLoading: boolean;
   error: string | null;
   setCurrentWorkspaceId: (workspaceId: string) => void;
@@ -77,6 +81,9 @@ type AccessStateRow = {
   industry?: string | null;
   role?: WorkspaceRole | null;
   memberCount?: number | null;
+  accessLevel?: DashboardAccessLevel | null;
+  isFounder?: boolean | null;
+  planBadgeLabel?: string | null;
 };
 
 type WorkspacePreferenceRow = {
@@ -89,18 +96,34 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
   const [memberCountByWorkspaceId, setMemberCountByWorkspaceId] = useState<Record<string, number>>({});
   const [currentWorkspaceId, setCurrentWorkspaceIdState] = useState<string | null>(null);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [accessLevel, setAccessLevel] = useState<DashboardAccessLevel | null>(null);
+  const [isFounder, setIsFounder] = useState(false);
+  const [planBadgeLabel, setPlanBadgeLabel] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const refreshWorkspaces = useCallback(async () => {
     setIsLoading(true);
     setError(null);
+    setAccessLevel(null);
+    setIsFounder(false);
+    setPlanBadgeLabel(null);
+
+    const accessStatePromise = fetch('/api/access/state', { credentials: 'include' })
+      .then((response) => (response.ok ? response.json() as Promise<AccessStateRow> : null))
+      .catch(() => null);
+
+    const applyAccessState = (data: AccessStateRow | null) => {
+      setAccessLevel(typeof data?.accessLevel === 'string' ? data.accessLevel : null);
+      setIsFounder(data?.isFounder === true);
+      setPlanBadgeLabel(typeof data?.planBadgeLabel === 'string' ? data.planBadgeLabel : null);
+    };
 
     try {
       const hydrateFromAccessState = async (): Promise<boolean> => {
-        const response = await fetch('/api/access/state', { credentials: 'include' });
-        if (!response.ok) return false;
-        const data = (await response.json()) as AccessStateRow;
+        const data = await accessStatePromise;
+        applyAccessState(data);
+        if (!data) return false;
         const workspaceId =
           (typeof data.workspaceId === 'string' && data.workspaceId) ||
           (typeof data.workspace_id === 'string' && data.workspace_id) ||
@@ -276,11 +299,12 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
           window.localStorage.removeItem(namespacedKey);
         }
       }
+      applyAccessState(await accessStatePromise);
     } catch (err) {
       try {
-        const response = await fetch('/api/access/state', { credentials: 'include' });
-        if (response.ok) {
-          const data = (await response.json()) as AccessStateRow;
+        const data = await accessStatePromise;
+        applyAccessState(data);
+        if (data) {
           const workspaceId =
             (typeof data.workspaceId === 'string' && data.workspaceId) ||
             (typeof data.workspace_id === 'string' && data.workspace_id) ||
@@ -400,6 +424,9 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
       memberCountByWorkspaceId,
       currentWorkspace,
       currentWorkspaceId,
+      accessLevel,
+      isFounder,
+      planBadgeLabel,
       isLoading,
       error,
       setCurrentWorkspaceId,
@@ -411,6 +438,9 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
       memberCountByWorkspaceId,
       currentWorkspace,
       currentWorkspaceId,
+      accessLevel,
+      isFounder,
+      planBadgeLabel,
       isLoading,
       error,
       setCurrentWorkspaceId,

--- a/lib/workspace-context.tsx
+++ b/lib/workspace-context.tsx
@@ -49,6 +49,7 @@ type WorkspaceContextValue = {
   accessLevel: DashboardAccessLevel | null;
   isFounder: boolean;
   planBadgeLabel: string | null;
+  redirectPath: string | null;
   isLoading: boolean;
   error: string | null;
   setCurrentWorkspaceId: (workspaceId: string) => void;
@@ -81,15 +82,53 @@ type AccessStateRow = {
   workspaceName?: string | null;
   industry?: string | null;
   role?: WorkspaceRole | null;
+  hasAccess?: boolean | null;
   memberCount?: number | null;
   accessLevel?: DashboardAccessLevel | null;
   isFounder?: boolean | null;
+  isSalesperson?: boolean | null;
   planBadgeLabel?: string | null;
+  onboardingComplete?: boolean | null;
+  unauthorized?: boolean;
 };
 
 type WorkspacePreferenceRow = {
   current_workspace_id?: string | null;
 };
+
+function computeRedirectPath(state: AccessStateRow, pathname: string): string | null {
+  if (pathname.startsWith('/reset-password')) return null;
+
+  const url = new URL(pathname, 'http://localhost');
+  const inviteToken = url.searchParams.get('token');
+  if (pathname.startsWith('/join') && inviteToken) return null;
+
+  const workspaceId = state.workspaceId || state.workspace_id || null;
+  if (!workspaceId) {
+    if (state.isFounder) return '/admin';
+    return '/download-ios?next=/onboarding';
+  }
+
+  if (state.accessLevel === 'founder') return null;
+  if (state.isSalesperson) return null;
+
+  if (!state.onboardingComplete && state.role === 'owner') {
+    return '/download-ios?next=/onboarding';
+  }
+
+  if (state.role === 'member' && !state.hasAccess) {
+    return '/subscribe?reason=member-inactive';
+  }
+
+  if (!state.hasAccess) return '/subscribe';
+
+  return null;
+}
+
+function currentPathWithSearch(): string {
+  if (typeof window === 'undefined') return '/home';
+  return `${window.location.pathname}${window.location.search}`;
+}
 
 export function WorkspaceProvider({ children }: { children: ReactNode }) {
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
@@ -100,6 +139,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
   const [accessLevel, setAccessLevel] = useState<DashboardAccessLevel | null>(null);
   const [isFounder, setIsFounder] = useState(false);
   const [planBadgeLabel, setPlanBadgeLabel] = useState<string | null>(null);
+  const [redirectPath, setRedirectPath] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const initialLoadDoneRef = useRef(false);
@@ -111,15 +151,28 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     setAccessLevel(null);
     setIsFounder(false);
     setPlanBadgeLabel(null);
+    setRedirectPath(null);
 
     const accessStatePromise = fetch('/api/access/state', { credentials: 'include' })
-      .then((response) => (response.ok ? response.json() as Promise<AccessStateRow> : null))
+      .then((response) => {
+        if (response.status === 401) return { unauthorized: true } satisfies AccessStateRow;
+        return response.ok ? response.json() as Promise<AccessStateRow> : null;
+      })
       .catch(() => null);
 
     const applyAccessState = (data: AccessStateRow | null) => {
+      if (data?.unauthorized) {
+        setAccessLevel(null);
+        setIsFounder(false);
+        setPlanBadgeLabel(null);
+        setRedirectPath('/login');
+        return;
+      }
+
       setAccessLevel(typeof data?.accessLevel === 'string' ? data.accessLevel : null);
       setIsFounder(data?.isFounder === true);
       setPlanBadgeLabel(typeof data?.planBadgeLabel === 'string' ? data.planBadgeLabel : null);
+      setRedirectPath(data ? computeRedirectPath(data, currentPathWithSearch()) : null);
     };
 
     try {
@@ -452,6 +505,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
       accessLevel,
       isFounder,
       planBadgeLabel,
+      redirectPath,
       isLoading,
       error,
       setCurrentWorkspaceId,
@@ -466,6 +520,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
       accessLevel,
       isFounder,
       planBadgeLabel,
+      redirectPath,
       isLoading,
       error,
       setCurrentWorkspaceId,


### PR DESCRIPTION
## What this does
Comprehensive performance overhaul of the home page load path. 
Eliminates redundant network calls, consolidates duplicated data 
fetching, parallelizes sequential DB queries, and adds client-side 
caching for repeat navigation.

## Changes

**Eliminate /api/access/redirect (saves ~1500ms per page)**
Merged redirect decision logic into WorkspaceContext using data 
already available from /api/access/state. MainRouteGuard now 
computes redirect client-side from context instead of making a 
separate network call on every page load across the entire app.
Added onboardingComplete to /api/access/state response to support 
the full redirect decision tree.

**Consolidate /api/access/state (3 calls → 1)**
MainLayoutClient and AppTopHeader were each independently fetching 
/api/access/state. Moved accessLevel, isFounder, and planBadgeLabel 
into WorkspaceContext so they are fetched once and shared. 
isAmbassador retained as a minimal separate fetch since it is not 
yet in WorkspaceContext.

**Prevent duplicate workspace loads**
WorkspaceProvider was calling refreshWorkspaces() on mount AND on 
the initial Supabase auth state event. Added initialLoadDone ref 
to skip INITIAL_SESSION events and only refresh on real auth changes.

**Prevent Strict Mode double-fetch**
HomeDashboardView and MyCampaignAssignmentsCard used per-instance 
refs for deduplication, which reset on Strict Mode remount. Replaced 
with module-level Sets that survive remounts. Added in-flight markers 
(add before fetch, delete on error) to prevent concurrent race.

**Parallelize DB queries in /api/access/state**
- Founder lookup and workspace resolution now run in parallel
- Role, member count, and max_seats run in parallel after workspace resolves
- Combined user_profiles queries (founder + current_workspace_id) into one
- Pre-fetched membership/workspace rows passed into 
  resolveDashboardAccessLevel() to avoid duplicate queries
- Salesperson lookup, ambassador check, and membership fetch run in parallel

**Client-side dashboard cache**
HomeDashboardView caches successful dashboard responses for 30 
seconds keyed by workspaceId. Second visit to /home within 30s 
serves from cache with no network call.

## Results
Before → After on warm home page load:
- API calls: 9 → 4
- /api/access/state: 3 calls → 1 call
- /api/access/redirect: 1 call → 0 calls
- /api/home/dashboard: 2 calls → 1 call (0 on cached repeat)
- /api/campaign-assignments: 2-3 calls → 1 call (0 on cached repeat)
- /home second load: ~2800ms → ~400ms

## Verified
- npx tsc --noEmit: 0 errors
- npm run build: 0 errors
- Verified in browser: single API calls on first load, zero redundant 
  calls on cached second load