### PR TITLE
fix: deduplicate integration status, billing entitlement, and dialer fetches

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -145,6 +145,14 @@ Adding a manual override on the web requires coordination with Daniel to ensure
 the web route doesn't conflict with iOS session behavior or create unexpected
 data state.
 
+### Ambassador landing page duplicate key error
+/api/ambassador/links and /api/ambassador/dashboard both call
+getOrCreateAmbassadorLandingPage() which throws on duplicate slug.
+Error: duplicate key value violates unique constraint
+"ambassador_landing_pages_slug_key"
+Both routes return 500 on first load then recover on retry.
+Action: Daniel to fix the upsert logic to handle existing slugs.
+
 ---
 
 ## Notes

--- a/app/(main)/settings/integrations/page.tsx
+++ b/app/(main)/settings/integrations/page.tsx
@@ -63,6 +63,8 @@ interface MondayBoard {
 
 type IntegrationGroup = 'real_estate' | 'trades';
 
+const inFlightIntegrations = new Set<string>();
+
 export default function IntegrationsPage() {
   const integrationLogoContainerClass = 'w-10 h-10 rounded-lg flex items-center justify-center';
   const integrationLogoIconClass = 'w-5 h-5';
@@ -155,27 +157,37 @@ export default function IntegrationsPage() {
 
   useEffect(() => {
     const loadData = async () => {
-      const supabase = createClient();
-      
-      // Get user
-      const { data: { user: authUser } } = await supabase.auth.getUser();
-      if (authUser) {
-        if (isRealEstate) {
-          await Promise.all([
-            loadConnectionStatus(currentWorkspaceId ?? undefined),
-            loadBoldTrailStatus(currentWorkspaceId ?? undefined),
-            loadHubSpotStatus(currentWorkspaceId ?? undefined),
-            loadZapierStatus(currentWorkspaceId ?? undefined),
-            loadMondayStatus(),
-          ]);
-        } else {
-          await loadContractorStatuses(currentWorkspaceId ?? undefined);
-        }
-      } else {
-        router.push('/login');
+      const requestKey = currentWorkspaceId ?? 'default';
+      if (inFlightIntegrations.has(requestKey)) {
+        setLoading(false);
+        return;
       }
-      
-      setLoading(false);
+      inFlightIntegrations.add(requestKey);
+
+      const supabase = createClient();
+
+      try {
+        // Get user
+        const { data: { user: authUser } } = await supabase.auth.getUser();
+        if (authUser) {
+          if (isRealEstate) {
+            await Promise.all([
+              loadConnectionStatus(currentWorkspaceId ?? undefined),
+              loadBoldTrailStatus(currentWorkspaceId ?? undefined),
+              loadHubSpotStatus(currentWorkspaceId ?? undefined),
+              loadZapierStatus(currentWorkspaceId ?? undefined),
+              loadMondayStatus(),
+            ]);
+          } else {
+            await loadContractorStatuses(currentWorkspaceId ?? undefined);
+          }
+        } else {
+          router.push('/login');
+        }
+      } finally {
+        inFlightIntegrations.delete(requestKey);
+        setLoading(false);
+      }
     };
 
     loadData();

--- a/app/(main)/settings/page.tsx
+++ b/app/(main)/settings/page.tsx
@@ -33,6 +33,8 @@ interface EntitlementSnapshot {
   planBadgeLabel?: string | null;
 }
 
+const inFlightBillingWorkspaceIds = new Set<string>();
+
 function SettingsPageContent() {
   const { theme, setTheme } = useTheme();
   const router = useRouter();
@@ -79,19 +81,27 @@ function SettingsPageContent() {
           }
 
           try {
-            const entRes = await retryWithBackoff(async () => {
-              const response = await fetch('/api/billing/entitlement', { credentials: 'include' });
-              if (response.status >= 500) {
-                throw response;
+            const entitlementKey = authUser.id;
+            if (!inFlightBillingWorkspaceIds.has(entitlementKey)) {
+              inFlightBillingWorkspaceIds.add(entitlementKey);
+              try {
+                const entRes = await retryWithBackoff(async () => {
+                  const response = await fetch('/api/billing/entitlement', { credentials: 'include' });
+                  if (response.status >= 500) {
+                    throw response;
+                  }
+                  return response;
+                });
+                if (entRes.ok) {
+                  const entData = await entRes.json();
+                  setEntitlement(entData);
+                } else {
+                  setEntitlement(null);
+                  setEntitlementError(true);
+                }
+              } finally {
+                inFlightBillingWorkspaceIds.delete(entitlementKey);
               }
-              return response;
-            });
-            if (entRes.ok) {
-              const entData = await entRes.json();
-              setEntitlement(entData);
-            } else {
-              setEntitlement(null);
-              setEntitlementError(true);
             }
           } catch (error) {
             console.error('Error loading entitlement:', error);

--- a/components/settings/PowerDialerSettingsCard.tsx
+++ b/components/settings/PowerDialerSettingsCard.tsx
@@ -33,6 +33,8 @@ type DialerSettingsStatus = {
   } | null;
 };
 
+const inFlightDialerSettingsWorkspaceIds = new Set<string>();
+
 export function PowerDialerSettingsCard() {
   const { currentWorkspaceId } = useWorkspace();
   const [dialerSettingsStatus, setDialerSettingsStatus] = useState<DialerSettingsStatus | null>(null);
@@ -47,6 +49,13 @@ export function PowerDialerSettingsCard() {
     : 'CA$19.99/month';
 
   const loadDialerSettingsStatus = async (workspaceId?: string) => {
+    const requestKey = workspaceId ?? 'default';
+    if (inFlightDialerSettingsWorkspaceIds.has(requestKey)) {
+      setLoading(false);
+      return;
+    }
+    inFlightDialerSettingsWorkspaceIds.add(requestKey);
+
     try {
       const qs = workspaceId ? `?workspaceId=${encodeURIComponent(workspaceId)}` : '';
       const response = await fetch(`/api/dialer/settings${qs}`);
@@ -57,6 +66,7 @@ export function PowerDialerSettingsCard() {
     } catch (error) {
       console.error('Error loading dialer settings:', error);
     } finally {
+      inFlightDialerSettingsWorkspaceIds.delete(requestKey);
       setLoading(false);
     }
   };


### PR DESCRIPTION
## What this does
Eliminates remaining duplicate API calls on settings pages and logs 
a known ambassador bug.

## Changes

**app/(main)/settings/integrations/page.tsx**
Added module-level in-flight dedup for integration status fetches.
Each status endpoint (zapier, followupboss, boldtrail, hubspot, monday) 
now called once per workspace instead of twice.

**app/(main)/settings/page.tsx**
Added module-level in-flight dedup for /api/billing/entitlement 
keyed by user ID.

**components/settings/PowerDialerSettingsCard.tsx**
Added module-level in-flight dedup for /api/dialer/settings 
keyed by workspaceId.

**KNOWN_ISSUES.md**
Logged ambassador landing page duplicate key constraint error — 
both /api/ambassador/links and /api/ambassador/dashboard throw on 
first load, recover on retry.

## Verified
- npx tsc --noEmit: 0 errors
- npm run build: 0 errors
- /settings/integrations: each status endpoint called once
- /settings: billing entitlement called once
- /api/dialer/settings: called once (500 expected locally — Twilio env not set)